### PR TITLE
Add .env.dev to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 testobj.py
 
 .env
+.env.dev


### PR DESCRIPTION
I wanna have a .env for local DB development and non-local DB development and I'd like to avoid committing creds.