### PR TITLE
Invoke the "nuclear" option to ignore the .idea/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 .DS_Store
 testobj.py
 


### PR DESCRIPTION
The readme template describes `.gitignore`-ing the `.idea` directory as "nuclear" and it is, in the sense that it makes it harder to share PyCharm configurations among developers. In my experience however, IDE configuration is highly personal and I've never worked with anyone who wanted to collaborate on PyCharm configs :( 

This cleans up my git diffs until such a time as someone would like to collaborate on IDEA configurations <3