### PR TITLE
Fix logging in the import script

### DIFF
--- a/src/meshdb/utils/spreadsheet_import/main.py
+++ b/src/meshdb/utils/spreadsheet_import/main.py
@@ -8,11 +8,14 @@ from typing import List
 import django
 from django.db.models import Q
 
+from meshdb.utils.spreadsheet_import import logger
+
+logger.configure()
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "meshdb.settings")
 django.setup()
 
 from meshapi import models
-from meshdb.utils.spreadsheet_import import logger
 from meshdb.utils.spreadsheet_import.building.resolve_address import AddressParser
 from meshdb.utils.spreadsheet_import.csv_load import (
     DroppedModification,
@@ -30,7 +33,6 @@ from meshdb.utils.spreadsheet_import.parse_member import get_or_create_member
 
 
 def main():
-    logger.configure()
     if len(sys.argv) != 4:
         print("Usage: meshdb-spreadsheet-import [Path to Form Responses CSV] [Path to Links CSV] [Path to Sectors CSV]")
         return


### PR DESCRIPTION
One of the django apps or dependencies (probably `django-webhooks`) is beating us to the `logging.configure` call, which breaks spreadsheet import logs starting with: ad58bedc553eb8e3d80c4b3e0e0a251a194ebd12

I think the general fix for the app is to beat them to the punch by initializing the logger in `settings.py` or something but for the import script I can just do it in the entrypoint