### PR TITLE
Setup automated backups with django-dbbackup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,12 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_PASSWORD=abcd1234
 
+# Backups
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+BACKUP_S3_BUCKET_NAME=meshdb-data-backups
+BACKUP_S3_BASE_FOLDER=meshdb-backups/development/
+
 CELERY_BROKER=redis://localhost:6379/0
 
 # DO NOT USE THIS KEY IN PRODUCTION

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,10 @@ services:
   redis:
     healthcheck:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+      interval: 3s
+      timeout: 3s
+      retries: 3
+      start_period: 1s
     networks:
       - api
     ports:
@@ -44,10 +48,10 @@ services:
          condition: service_healthy
     healthcheck:
       test: curl http://127.0.0.1:8081/api/v1
-      interval: 2s
-      timeout: 1s
+      interval: 3s
+      timeout: 3s
       retries: 3
-      start_period: 2s
+      start_period: 4s
     networks:
       - api
     env_file:
@@ -55,6 +59,9 @@ services:
     volumes:
       - static_files:/opt/meshdb/static
     image: willnilges/meshdb:main
+    build:
+      context: .
+      dockerfile: ./Dockerfile
 
   nginx:
     depends_on:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,9 @@ echo 'DB started'
 # are executed as soon as celery starts
 # FIXME: This makes testing locally a bit awkward, since this isn't started by "manage.py runserver"
 #  maybe there's a way to do this better?
-echo 'Staring Celery Worker...'
-celery -A meshdb worker -l INFO --detach
+echo 'Starting Celery Worker...'
+celery -A meshdb worker -l DEBUG -f /var/log/meshdb-celery.log &
+celery -A meshdb beat -l DEBUG -f /var/log/meshdb-celery-beat.log -s /tmp/celerybeat-schedule &
 
 echo 'Running Migrations...'
 python manage.py makemigrations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
     # FIXME: Go back to PyPI when https://github.com/bhch/django-jsonform/pull/162 is merged
     "django-jsonform@git+https://github.com/willnilges/django-jsonform.git@51cbed42ccdaec81a35c97a919d054e2c9ca0207",
     "faker==24.3.*",
+    # FIXME: Go back to PyPI when https://github.com/jazzband/django-dbbackup/pull/515 or https://github.com/jazzband/django-dbbackup/pull/511 is merged
+    "django-dbbackup@git+https://github.com/willnilges/django-dbbackup.git@62048411ff5beac4beac1578f686824214f1f33a",
+    "django-storages==1.14.*",
+    "boto3==1.34.*",
 ]
 
 [project.optional-dependencies]

--- a/src/meshapi/tasks.py
+++ b/src/meshapi/tasks.py
@@ -1,0 +1,33 @@
+import os
+
+from celery.schedules import crontab
+from django.core import management
+
+from meshapi.views.panoramas import sync_github_panoramas
+from meshdb.celery import app as celery_app
+
+
+@celery_app.task
+def run_database_backup():
+    if not os.environ.get("AWS_ACCESS_KEY_ID") or not os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        print("Could not run backup. Missing AWS credentials!")
+        return
+
+    management.call_command("dbbackup")
+
+
+@celery_app.task
+def run_update_panoramas():
+    sync_github_panoramas()
+
+
+celery_app.conf.beat_schedule = {
+    "run-database-backup-hourly": {
+        "task": "meshapi.tasks.run_database_backup",
+        "schedule": crontab(minute="0", hour="*/1"),
+    },
+    "update-panoramas-hourly": {
+        "task": "meshapi.tasks.run_update_panoramas",
+        "schedule": crontab(minute="0", hour="*/1"),
+    },
+}

--- a/src/meshapi/tests/test_update_panos_github.py
+++ b/src/meshapi/tests/test_update_panos_github.py
@@ -110,7 +110,7 @@ class TestPanoAuthentication(TestCase):
         }
         mock_requests.return_value = mock_response
 
-        response = self.admin_c.get("/api/v1/update-panoramas/")
+        response = self.admin_c.post("/api/v1/update-panoramas/")
         code = 200
         self.assertEqual(
             code,

--- a/src/meshapi/urls.py
+++ b/src/meshapi/urls.py
@@ -34,5 +34,5 @@ urlpatterns = [
     path("mapdata/links/", views.MapDataLinkList.as_view(), name="meshapi-v1-map-data-links"),
     path("mapdata/sectors/", views.MapDataSectorList.as_view(), name="meshapi-v1-map-data-sectors"),
     path("geography/whole-mesh.kml", views.WholeMeshKML.as_view(), name="meshapi-v1-geography-whole-mesh-kml"),
-    path("update-panoramas/", views.update_panoramas_from_github, name="meshapi-v1-update-panoramas"),
+    path("update-panoramas/", views.update_panoramas, name="meshapi-v1-update-panoramas"),
 ]

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -93,6 +93,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "django_filters",
     "django_jsonform",
+    "dbbackup",
 ]
 
 MIDDLEWARE = [
@@ -149,6 +150,21 @@ DATABASES = {
     }
 }
 
+# django-dbbackup
+# https://django-dbbackup.readthedocs.io/en/master/installation.html
+
+DBBACKUP_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+DBBACKUP_STORAGE_OPTIONS = {
+    "bucket_name": os.environ.get("BACKUP_S3_BUCKET_NAME"),
+    "location": os.environ.get("BACKUP_S3_BASE_FOLDER"),
+}
+
+DBBACKUP_CONNECTORS = {
+    "default": {
+        # "SINGLE_TRANSACTION": False,
+        "IF_EXISTS": True
+    }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
Installs `django-dbbackup` to provide the ability to back up our database automatically. Configures a celery beat to do so hourly.

Also fixes celery beat for syncing panoramas, and tweaks the `entrypoint.sh` to avoid celery locking up and using 100% CPU.