### PR TITLE
Only show node name labels on NN map dots

### DIFF
--- a/src/meshapi/serializers/map.py
+++ b/src/meshapi/serializers/map.py
@@ -65,7 +65,11 @@ class MapDataInstallSerializer(serializers.ModelSerializer):
         return [building.longitude, building.latitude, building.altitude]
 
     def get_node_name(self, install: Install) -> Optional[str]:
-        node = install.node
+        # Only include the node name if this is an old-school "node as install" situation
+        # to prevent showing the same name on multiple map dots. For the NN != install number
+        # case we add extra fake install objects with install_number = NN so that we can still
+        # see the node name
+        node = install.node if install.node.network_number == install.install_number else None
         return node.name if node else None
 
     def get_synthetic_notes(self, install: Install) -> Optional[str]:

--- a/src/meshapi/serializers/map.py
+++ b/src/meshapi/serializers/map.py
@@ -69,8 +69,8 @@ class MapDataInstallSerializer(serializers.ModelSerializer):
         # to prevent showing the same name on multiple map dots. For the NN != install number
         # case we add extra fake install objects with install_number = NN so that we can still
         # see the node name
-        node = install.node if install.node.network_number == install.install_number else None
-        return node.name if node else None
+        node = install.node
+        return node.name if node and install.node.network_number == install.install_number else None
 
     def get_synthetic_notes(self, install: Install) -> Optional[str]:
         if not install.node:

--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -175,6 +175,7 @@ class TestViewsGetUnauthenticated(TestCase):
         nodes.append(
             Node(
                 network_number=567,
+                name="Fancy Node",
                 status=Node.NodeStatus.PLANNED,
                 latitude=40.724868,
                 longitude=-73.987881,
@@ -314,6 +315,7 @@ class TestViewsGetUnauthenticated(TestCase):
                 },
                 {
                     "id": 567,
+                    "name": "Fancy Node",
                     "coordinates": [-73.9917741, 40.6962265, 66.0],
                     "requestDate": 1706331600000,
                     "roofAccess": True,

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -70,6 +70,7 @@ class MapDataNodeList(generics.ListAPIView):
                 all_installs.append(
                     Install(
                         install_number=node.network_number,
+                        node=node,
                         status=Install.InstallStatus.NN_REASSIGNED
                         if node.status == node.NodeStatus.ACTIVE
                         else Install.InstallStatus.REQUEST_RECEIVED,


### PR DESCRIPTION
Based on conversation with Olivier [here](https://nycmesh.slack.com/archives/C06GW3Q92TY/p1711983533597739?thread_ts=1711769003.400379&cid=C06GW3Q92TY), we should only show the node name on the NN dot, not the install dots. 

There's some follow-on work here to properly import node-name in some re-used NN edge cases, so this won't perfectly satisfy Olivier. I've captured that follow-on work via #314 