### PR TITLE
Pin 'shimataro/ssh-key-action'

### DIFF
--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install SSH key
-      uses: shimataro/ssh-key-action@v2
+      uses: shimataro/ssh-key-action@d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 # v2
       with:
         key: ${{ secrets.GRANDSVC_KEY }}
         name: id_ed25519 # optional


### PR DESCRIPTION
Pin the last unpinned third-party action. `shimataro/ssh-key-action` to commit [d4fffb50872869abe2d9a9098a6d9c5aa7d16be4](https://github.com/shimataro/ssh-key-action/commit/d4fffb50872869abe2d9a9098a6d9c5aa7d16be4) = `@v2`

Reasoning: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions