### PR TITLE
Convert print -> logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ loadenv.sh
 
 # Spreadsheet data
 spreadsheet_data
+
+# vs code
+.devcontainer.json

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -119,7 +119,7 @@ def join_form(request):
         # If the user has given us an invalid address. Tell them to buzz
         # off.
         except AddressError as e:
-            print(e)
+            logging.exception("AddressError when validating address")
             return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         # If we get any other error, then there was probably an issue
         # using the API, and we should wait a bit and re-try

--- a/src/meshapi/views/panoramas.py
+++ b/src/meshapi/views/panoramas.py
@@ -45,8 +45,8 @@ def update_panoramas(request):
             status=status.HTTP_200_OK,
         )
     except (ValueError, GitHubError) as e:
-        print(e)
-        return Response({"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        logging.exception("Error when syncing panoramas")
+        return Response({"detail": str(type(e).__name__)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 @advisory_lock("update_panoramas_lock")


### PR DESCRIPTION
- Convert `print()` to `logging.*()`, especially `logging.exception()` for exceptions
- In one case, limit error message detail to the class name
- Add a `.gitignore` entry for myself