### PR TITLE
Improve panorama appearance, make clickable

### DIFF
--- a/src/meshapi/templates/widgets/panorama_viewer.html
+++ b/src/meshapi/templates/widgets/panorama_viewer.html
@@ -1,5 +1,5 @@
 <div style='display:flex; flex-direction: row; width:100%; overflow-x:auto; max-height:300px; padding-left: 10px;'>
 	{% for panorama in widget.value %}
-		<img src="{{ panorama }}" height="300px"/>
+		<img src="{{ panorama }}" style="margin-right:10px"/>
 	{% endfor %}
 </div>

--- a/src/meshapi/templates/widgets/panorama_viewer.html
+++ b/src/meshapi/templates/widgets/panorama_viewer.html
@@ -1,5 +1,5 @@
 <div style='display:flex; flex-direction: row; width:100%; overflow-x:auto; max-height:300px; padding-left: 10px;'>
 	{% for panorama in widget.value %}
-		<img src="{{ panorama }}" style="margin-right:10px"/>
+		<a href="{{ panorama }}" target="_blank"><img src="{{ panorama }}" style="margin-right:10px"/></a>
 	{% endfor %}
 </div>


### PR DESCRIPTION
No longer squishes panoramas, instead resizes the div.

Also, make the panoramas clickable, and confirmed that panoramas show up in Windows.