### PR TITLE
Add new building objects from the BuildingInline

### DIFF
--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -41,6 +41,11 @@ class BetterNonrelatedInline(NonrelatedTabularInline):
         }
 
 
+class MembershipInline(admin.TabularInline):
+    model = Building.nodes.through
+    extra = 0
+    autocomplete_fields = ["building_id"]
+
 class NonrelatedBuildingInline(BetterNonrelatedInline):
     model = Building
     fields = ["primary_node", "bin", "street_address", "city", "zip_code"]
@@ -506,7 +511,7 @@ class NodeAdmin(admin.ModelAdmin):
             },
         ),
     ]
-    inlines = [InstallInline, NonrelatedBuildingInline, DeviceInline, SectorInline, NodeLinkInline]
+    inlines = [InstallInline, MembershipInline, NonrelatedBuildingInline, DeviceInline, SectorInline, NodeLinkInline]
 
     def address(self, obj):
         return obj.buildings.first()

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -41,11 +41,6 @@ class BetterNonrelatedInline(NonrelatedTabularInline):
         }
 
 
-class MembershipInline(admin.TabularInline):
-    model = Building.nodes.through
-    extra = 0
-    autocomplete_fields = ["building_id"]
-
 class NonrelatedBuildingInline(BetterNonrelatedInline):
     model = Building
     fields = ["primary_node", "bin", "street_address", "city", "zip_code"]
@@ -62,6 +57,15 @@ class NonrelatedBuildingInline(BetterNonrelatedInline):
 
     def save_new_instance(self, parent, instance):
         pass
+
+
+class BuildingMembershipInline(admin.TabularInline):
+    model = Building.nodes.through
+    extra = 0
+    autocomplete_fields = ["building_id"]
+    classes = ["collapse"]
+    verbose_name = "Building"
+    verbose_name_plural = "Edit Related Buildings"
 
 
 # This controls the list of installs reverse FK'd to Buildings and Members
@@ -511,7 +515,14 @@ class NodeAdmin(admin.ModelAdmin):
             },
         ),
     ]
-    inlines = [InstallInline, MembershipInline, NonrelatedBuildingInline, DeviceInline, SectorInline, NodeLinkInline]
+    inlines = [
+        InstallInline,
+        NonrelatedBuildingInline,
+        BuildingMembershipInline,
+        DeviceInline,
+        SectorInline,
+        NodeLinkInline,
+    ]
 
     def address(self, obj):
         return obj.buildings.first()

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -46,6 +46,8 @@ class NonrelatedBuildingInline(BetterNonrelatedInline):
     fields = ["primary_node", "bin", "street_address", "city", "zip_code"]
     readonly_fields = fields
 
+    add_button = True
+
     def get_form_queryset(self, obj):
         return self.model.objects.filter(nodes=obj)
 

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -48,7 +48,11 @@ class NonrelatedBuildingInline(BetterNonrelatedInline):
 
     add_button = True
 
+    # Hack to get the NN
+    network_number = None
+
     def get_form_queryset(self, obj):
+        self.network_number = obj.pk
         return self.model.objects.filter(nodes=obj)
 
     def save_new_instance(self, parent, instance):

--- a/src/meshapi/templates/admin/install_tabular.html
+++ b/src/meshapi/templates/admin/install_tabular.html
@@ -70,5 +70,16 @@
      </tbody>
    </table>
 </fieldset>
+  <div>
+    <p>test</p>
+    {% if inline_admin_formset.opts.add_button %}
+    <p>{{ inline_admin_formset.opts }}</p>
+    <p>{{ inline_admin_formset.opts.model }}</p>
+    <p>{{ inline_admin_form.opts.model }}</p>
+    <p>{% url 'request.get_host()' %}</p>
+    <p>{% url 'admin:meshapi_building_add' %}</p>
+    <a href="{{ inline_admin_formset.opts.model.add_url }}" class="addlink">Add</a>
+    {% endif %}
+  </div>
   </div>
 </div>

--- a/src/meshapi/templates/admin/install_tabular.html
+++ b/src/meshapi/templates/admin/install_tabular.html
@@ -70,15 +70,10 @@
      </tbody>
    </table>
 </fieldset>
+  <!--TODO: Add collapsible menu to add existing buildings...?-->
   <div>
-    <p>test</p>
     {% if inline_admin_formset.opts.add_button %}
-    <p>{{ inline_admin_formset.opts }}</p>
-    <p>{{ inline_admin_formset.opts.model }}</p>
-    <p>{{ inline_admin_form.opts.model }}</p>
-    <p>{% url 'request.get_host()' %}</p>
-    <p>{% url 'admin:meshapi_building_add' %}</p>
-    <a href="{{ inline_admin_formset.opts.model.add_url }}" class="addlink">Add</a>
+      <a href="{{ request.scheme }}://{{ request.get_host }}{% url 'admin:meshapi_building_add' %}?primary_node={{ inline_admin_formset.opts.network_number }}" class="addlink">Add</a>
     {% endif %}
   </div>
   </div>


### PR DESCRIPTION
Enables jumping straight to the Building add view from the Node change view. I believe this solves half of the problem.

Update: I've done it, I've cracked the code. You have to use a "through" Inline. That is done here. In a followup PR I will clean up the Admin panel code and implement that for other fields.