### PR TITLE
Tell people to fork the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ wiki](https://wiki.mesh.nycmesh.net/books/services-software/chapter/meshdb)
 The production environment relies on Nginx and Gunicorn, but for development,
 you can use Django's tools. You'll also need Python 3.11, and pip, of course.
 
+Firstly, fork this repo.
+
 For safety, create a venv
 
 ```


### PR DESCRIPTION
New people who want to contribute should fork it so that they can set it up and contribute. Don't want them to clone the main one and then need to change their base.

TODO: Add changing base instructions?