### PR TITLE
Add devcontainer file

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "image": "docker.io/python:3.11-bookworm",
+    "runArgs": [
+        "--network=host",
+    ],
+    "postStartCommand": "pip install -e '.[dev]'"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -176,5 +176,3 @@ loadenv.sh
 # Spreadsheet data
 spreadsheet_data
 
-# vs code
-.devcontainer.json

--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ Firstly, fork this repo.
 > git remote add upstream https://github.com/nycmeshnet/meshdb
 > ```
 
-For safety, create a venv
+#### Dev Container
+
+If you would like to develop in a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers)
+
+1. Make sure you have VS Code installed.
+2. Install the Dev Containers extension: `ms-vscode-remote.remote-containers`
+3. [Open the repo folder in the container](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container).
+4. In a different shell, outside of VS Code, start the other containers: `docker compose up -d postgres pelias redis` (as below).
+5. Continue on the VS Code terminal (where your project is opened) follow normal developer setup.
+
+#### Host
+
+If you are not using a Dev Container, for safety, create a venv
 
 ```
 python --version # Make sure this is python 3.11.x before continuing
@@ -47,6 +59,8 @@ Then, install dependencies.
 ```
 pip install -e '.[dev]'
 ```
+
+### Set Environment Variables
 
 Next, fill out the `.env.sample` file and load it into your environment.
 


### PR DESCRIPTION
To use this:

1. Install the best IDE (VS Code)
2. Install the Dev Containers extension: `ms-vscode-remote.remote-containers`
3. [Open the repo folder in the container](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container)
4. In a different shell, start the other containers: `docker compose up -d postgres pelias redis`
5. In the VS Code terminal (where your project is opened) follow normal developer setup (no venv needed)
```
python src/manage.py makemigrations
python src/manage.py migrate
python src/manage.py createsuperuser
python src/manage.py runserver
python src/manage.py test meshapi meshapi_hooks
invoke lint
invoke format
...
```