### PR TITLE
Fix DB import script

### DIFF
--- a/import_spreadsheet_dump.sh
+++ b/import_spreadsheet_dump.sh
@@ -53,8 +53,8 @@ do
         max_id=$(($($DOCKER_PG_COMMAND -c "SELECT MAX(install_number) FROM $table_name" -At) + 1))
         $DOCKER_PG_COMMAND -c "ALTER SEQUENCE "$table_name"_install_number_seq RESTART WITH $max_id"
     elif [[ "$table_name" == "meshapi_node" ]]; then
-        max_id=$(($($DOCKER_PG_COMMAND -c "SELECT MAX(network_number) FROM $table_name" -At) + 1))
-        $DOCKER_PG_COMMAND -c "ALTER SEQUENCE "$table_name"_network_number_seq RESTART WITH $max_id"
+        : # Do nothing, we don't use the database to auto-increment node numbers,
+        # they are assigned via a dedicated python function
     else
         max_id=$(($($DOCKER_PG_COMMAND -c "SELECT MAX(id) FROM $table_name" -At) + 1))
         $DOCKER_PG_COMMAND -c "ALTER SEQUENCE "$table_name"_id_seq RESTART WITH $max_id"


### PR DESCRIPTION
The node table no longer has an auto-incrementing sequence, so the import script fails. This PR removes the line that tries to update the auto-increment counter at import time