### PR TITLE
Clean up add button on reverse inlines

### DIFF
--- a/src/meshapi/admin/inlines.py
+++ b/src/meshapi/admin/inlines.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
-import django.db.models
 from django.contrib import admin
+from django.contrib.admin import AdminSite
 from django.db.models import Model, Q, QuerySet
 from django.http import HttpRequest
 from nonrelated_inlines.admin import NonrelatedTabularInline
@@ -139,8 +139,8 @@ class InstallInline(BetterInline):
     fields = ["status", "node", "member", "building", "unit"]
     readonly_fields = fields  # type: ignore[assignment]
 
-    def __init__(self, model: Model, *args, **kwargs):
-        super().__init__(model, *args, **kwargs)
+    def __init__(self, model: type[Any], admin_site: AdminSite):
+        super().__init__(model, admin_site)
 
         self.add_button = False
         self.reverse_relation = None

--- a/src/meshapi/admin/inlines.py
+++ b/src/meshapi/admin/inlines.py
@@ -1,11 +1,12 @@
 from typing import Any, Optional
 
+import django.db.models
 from django.contrib import admin
 from django.db.models import Model, Q, QuerySet
 from django.http import HttpRequest
 from nonrelated_inlines.admin import NonrelatedTabularInline
 
-from meshapi.models import Building, Device, Install, Link, Node, Sector
+from meshapi.models import Building, Device, Install, Link, Member, Node, Sector
 
 
 # Inline with the typical rules we want + Formatting
@@ -70,6 +71,7 @@ class NonrelatedBuildingInline(BetterNonrelatedInline):
     readonly_fields = fields
 
     add_button = True
+    reverse_relation = "primary_node"
 
     # Hack to get the NN
     network_number = None
@@ -136,3 +138,19 @@ class InstallInline(BetterInline):
     model = Install
     fields = ["status", "node", "member", "building", "unit"]
     readonly_fields = fields  # type: ignore[assignment]
+
+    def __init__(self, model: Model, *args, **kwargs):
+        super().__init__(model, *args, **kwargs)
+
+        self.add_button = False
+        self.reverse_relation = None
+
+        if model == Building:
+            self.add_button = True
+            self.reverse_relation = "building"
+        elif model == Node:
+            self.add_button = True
+            self.reverse_relation = "node"
+        elif model == Member:
+            self.add_button = True
+            self.reverse_relation = "member"

--- a/src/meshapi/static/admin/install_tabular.css
+++ b/src/meshapi/static/admin/install_tabular.css
@@ -11,3 +11,12 @@ td.original p {
 .inline-group .tabular tr.has_original td {
     padding-top: 5px;
 }
+
+.inline-action-row {
+    padding: 12px 14px 12px;
+    margin: 0 0 10px;
+    overflow: hidden;
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+}

--- a/src/meshapi/templates/admin/install_tabular.html
+++ b/src/meshapi/templates/admin/install_tabular.html
@@ -71,9 +71,9 @@
    </table>
 </fieldset>
   <!--TODO: Add collapsible menu to add existing buildings...?-->
-  <div>
+  <div class="inline-action-row">
     {% if inline_admin_formset.opts.add_button %}
-      <a href="{{ request.scheme }}://{{ request.get_host }}{% url 'admin:meshapi_building_add' %}?primary_node={{ inline_admin_formset.opts.network_number }}" class="addlink">Add</a>
+      <a href="{{ request.scheme }}://{{ request.get_host }}{% url 'admin:'|add:inline_admin_formset.opts.opts.db_table|add:'_add' %}?{{ inline_admin_formset.opts.reverse_relation }}={{ object_id }}" class="addlink">Add {{ inline_admin_formset.opts.verbose_name|capfirst }}</a>
     {% endif %}
   </div>
   </div>


### PR DESCRIPTION
Fix the spacing around the "Add" button that appears under Building inlines, and extend it to Install inlines also