### PR TITLE
Make pagination uniform across endpoints & add tests

### DIFF
--- a/src/meshapi/tests/test_pagination.py
+++ b/src/meshapi/tests/test_pagination.py
@@ -1,0 +1,114 @@
+import json
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+
+from meshapi.tests.sample_data import sample_member
+
+from ..models import Member
+
+
+class TestPagination(TestCase):
+    c = Client()
+
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+        self.c.login(username="admin", password="admin_password")
+
+    def test_member_list_pagination(self):
+        for i in range(999):
+            member = Member(**sample_member)
+            member.save()
+
+        response = self.c.get("/api/v1/members/")
+        code = 200
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+
+        self.assertEqual(len(response_obj["results"]), 100)
+        self.assertEqual(response_obj["count"], 999)
+        self.assertEqual(response_obj["previous"], None)
+        self.assertEqual(response_obj["next"], "http://testserver/api/v1/members/?page=2")
+
+        response = self.c.get("/api/v1/members/?page=2")
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+
+        self.assertEqual(len(response_obj["results"]), 100)
+        self.assertEqual(response_obj["count"], 999)
+        self.assertEqual(response_obj["previous"], "http://testserver/api/v1/members/")
+        self.assertEqual(response_obj["next"], "http://testserver/api/v1/members/?page=3")
+
+        response = self.c.get("/api/v1/members/?page_size=999999")
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+
+        self.assertEqual(len(response_obj["results"]), 999)
+        self.assertEqual(response_obj["count"], 999)
+        self.assertEqual(response_obj["previous"], None)
+        self.assertEqual(response_obj["next"], None)
+
+    def test_member_lookup_pagination(self):
+        for i in range(999):
+            member = Member(**sample_member)
+            member.save()
+
+        response = self.c.get("/api/v1/members/lookup/?name=John+Smith")
+        code = 200
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+
+        self.assertEqual(len(response_obj["results"]), 100)
+        self.assertEqual(response_obj["count"], 999)
+        self.assertEqual(response_obj["previous"], None)
+        self.assertEqual(response_obj["next"], "http://testserver/api/v1/members/lookup/?name=John+Smith&page=2")
+
+        response = self.c.get("/api/v1/members/lookup/?name=John+Smith&page=2")
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+
+        self.assertEqual(len(response_obj["results"]), 100)
+        self.assertEqual(response_obj["count"], 999)
+        self.assertEqual(response_obj["previous"], "http://testserver/api/v1/members/lookup/?name=John+Smith")
+        self.assertEqual(response_obj["next"], "http://testserver/api/v1/members/lookup/?name=John+Smith&page=3")
+
+        response = self.c.get("/api/v1/members/lookup/?name=John+Smith&page_size=999999")
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+
+        self.assertEqual(len(response_obj["results"]), 999)
+        self.assertEqual(response_obj["count"], 999)
+        self.assertEqual(response_obj["previous"], None)
+        self.assertEqual(response_obj["next"], None)

--- a/src/meshapi/util/drf_utils.py
+++ b/src/meshapi/util/drf_utils.py
@@ -1,0 +1,5 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class CustomSizePageNumberPagination(PageNumberPagination):
+    page_size_query_param = "page_size"  # items per page

--- a/src/meshapi/views/lookups.py
+++ b/src/meshapi/views/lookups.py
@@ -23,10 +23,6 @@ from meshapi.serializers import (
 ADDITIONAL_QUERY_PARAMS = {"page_size", "page"}
 
 
-class CustomSizePageNumberPagination(PageNumberPagination):
-    page_size_query_param = "page_size"  # items per page
-
-
 class FilterRequiredListAPIView(generics.ListAPIView):
     filterset_class: Type[filters.FilterSet]
 
@@ -100,7 +96,6 @@ class LookupMember(FilterRequiredListAPIView):
     queryset = Member.objects.all().order_by("id")
     serializer_class = MemberSerializer
     filterset_class = MemberFilter
-    pagination_class = CustomSizePageNumberPagination
 
 
 class InstallFilter(filters.FilterSet):
@@ -150,7 +145,6 @@ class LookupInstall(FilterRequiredListAPIView):
     queryset = Install.objects.all().order_by("install_number")
     serializer_class = InstallSerializer
     filterset_class = InstallFilter
-    pagination_class = CustomSizePageNumberPagination
 
 
 class BuildingFilter(filters.FilterSet):
@@ -233,7 +227,6 @@ class LookupBuilding(FilterRequiredListAPIView):
     queryset = Building.objects.all().order_by("id")
     serializer_class = BuildingSerializer
     filterset_class = BuildingFilter
-    pagination_class = CustomSizePageNumberPagination
 
 
 class NodeFilter(filters.FilterSet):
@@ -285,7 +278,6 @@ class LookupNode(FilterRequiredListAPIView):
     queryset = Node.objects.all().order_by("network_number")
     serializer_class = NodeSerializer
     filterset_class = NodeFilter
-    pagination_class = CustomSizePageNumberPagination
 
 
 class LinkFilter(filters.FilterSet):
@@ -349,7 +341,6 @@ class LookupLink(FilterRequiredListAPIView):
     queryset = Link.objects.all().order_by("id")
     serializer_class = LinkSerializer
     filterset_class = LinkFilter
-    pagination_class = CustomSizePageNumberPagination
 
 
 class DeviceFilter(filters.FilterSet):
@@ -421,7 +412,6 @@ class LookupDevice(FilterRequiredListAPIView):
     queryset = Device.objects.all().order_by("id")
     serializer_class = DeviceSerializer
     filterset_class = DeviceFilter
-    pagination_class = CustomSizePageNumberPagination
 
 
 class SectorFilter(DeviceFilter):
@@ -490,4 +480,3 @@ class LookupSector(FilterRequiredListAPIView):
     queryset = Sector.objects.all().order_by("id")
     serializer_class = SectorSerializer
     filterset_class = SectorFilter
-    pagination_class = CustomSizePageNumberPagination

--- a/src/meshapi/views/lookups.py
+++ b/src/meshapi/views/lookups.py
@@ -5,7 +5,6 @@ from django_filters import rest_framework as filters
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import generics
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
 

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -223,7 +223,7 @@ STATICFILES_DIRS = [
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "DEFAULT_PAGINATION_CLASS": "meshapi.util.drf_utils.CustomSizePageNumberPagination",
     "PAGE_SIZE": 100,
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",


### PR DESCRIPTION
The rapid fire fixes in #435 and #434 only fixed pagination in the `/lookup` endpoints. This PR makes pagination behavior uniform across all endpoints, and adds tests to validate this is the case