### PR TITLE
Fix: import script crashes on datetime object

### DIFF
--- a/src/meshdb/utils/spreadsheet_import/csv_load.py
+++ b/src/meshdb/utils/spreadsheet_import/csv_load.py
@@ -311,12 +311,12 @@ def get_spreadsheet_sectors(sectors_path: str) -> List[SpreadsheetSector]:
 
         for i, row in enumerate(csv_reader):
             try:
-                install_date = datetime.datetime.strptime(row["installDate"], "%m/%d/%Y")
+                install_date = datetime.datetime.strptime(row["installDate"], "%m/%d/%Y").date()
             except ValueError:
                 install_date = None
 
             try:
-                abandon_date = datetime.datetime.strptime(row["abandonDate"], "%m/%d/%Y")
+                abandon_date = datetime.datetime.strptime(row["abandonDate"], "%m/%d/%Y").date()
             except ValueError:
                 abandon_date = None
 


### PR DESCRIPTION
It's unclear why these keep surfacing (#392 being the other recent example). But for some reason we didn't catch these earlier? 

We definitely want date objects, not datetime ones, Django rejects datetime objects on date fields, idk why this ever worked