### PR TITLE
Add django-cacheback to cache map JSON blobs for faster map render

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
       - api
     image:
       redis
+    ports:
+      - 6379:6379
 
   pgadmin:
     networks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "fastkml[lxml]==1.0a12", # FIXME: Update me to stable, once 1.0 is released officially
     "drf-spectacular==0.27.*",
     "djangorestframework-dataclasses==1.3.*",
+    "django-cacheback[celery]==3.0.*",
     "django-nonrelated-inlines==0.2.*",
     "django-filter==24.1",
     # FIXME: Go back to PyPI when https://github.com/bhch/django-jsonform/pull/162 is merged

--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -14,9 +14,9 @@ class TestViewsGetUnauthenticated(TestCase):
 
     def test_views_get_unauthenticated(self):
         routes = [
-            ("/api/v1/mapdata/nodes/", 200),
-            ("/api/v1/mapdata/links/", 200),
-            ("/api/v1/mapdata/sectors/", 200),
+            ("/api/v1/mapdata/nodes/?nocache=true", 200),
+            ("/api/v1/mapdata/links/?nocache=true", 200),
+            ("/api/v1/mapdata/sectors/?nocache=true", 200),
         ]
 
         for route, code in routes:
@@ -281,7 +281,7 @@ class TestViewsGetUnauthenticated(TestCase):
             install.save()
 
         self.maxDiff = None
-        response = self.c.get("/api/v1/mapdata/nodes/")
+        response = self.c.get("/api/v1/mapdata/nodes/?nocache=true")
 
         self.assertEqual(
             json.loads(response.content.decode("UTF8")),
@@ -466,7 +466,7 @@ class TestViewsGetUnauthenticated(TestCase):
         install.save()
 
         self.maxDiff = None
-        response = self.c.get("/api/v1/mapdata/sectors/")
+        response = self.c.get("/api/v1/mapdata/sectors/?nocache=true")
 
         self.assertEqual(
             json.loads(response.content.decode("UTF8")),
@@ -872,7 +872,7 @@ class TestViewsGetUnauthenticated(TestCase):
         self_loop_los.save()
 
         self.maxDiff = None
-        response = self.c.get("/api/v1/mapdata/links/")
+        response = self.c.get("/api/v1/mapdata/links/?nocache=true")
 
         self.assertEqual(
             json.loads(response.content.decode("UTF8")),
@@ -1064,7 +1064,7 @@ class TestViewsGetUnauthenticated(TestCase):
             link.save()
 
         self.maxDiff = None
-        response = self.c.get("/api/v1/mapdata/links/")
+        response = self.c.get("/api/v1/mapdata/links/?nocache=true")
 
         self.assertEqual(
             json.loads(response.content.decode("UTF8")),
@@ -1169,7 +1169,7 @@ class TestViewsGetUnauthenticated(TestCase):
             link.save()
 
         self.maxDiff = None
-        response = self.c.get("/api/v1/mapdata/links/")
+        response = self.c.get("/api/v1/mapdata/links/?nocache=true")
 
         self.assertEqual(
             json.loads(response.content.decode("UTF8")),
@@ -1326,7 +1326,7 @@ class TestViewsGetUnauthenticated(TestCase):
             link.save()
 
         self.maxDiff = None
-        response = self.c.get("/api/v1/mapdata/links/")
+        response = self.c.get("/api/v1/mapdata/links/?nocache=true")
 
         self.assertEqual(
             json.loads(response.content.decode("UTF8")),

--- a/src/meshapi/urls.py
+++ b/src/meshapi/urls.py
@@ -33,9 +33,9 @@ urlpatterns = [
     path("query/buildings/", views.QueryBuilding.as_view(), name="meshapi-v1-query-building"),
     path("query/members/", views.QueryMember.as_view(), name="meshapi-v1-query-member"),
     path("query/installs/", views.QueryInstall.as_view(), name="meshapi-v1-query-install"),
-    path("mapdata/nodes/", views.MapDataNodeList.as_view(), name="meshapi-v1-map-data-installs"),
-    path("mapdata/links/", views.MapDataLinkList.as_view(), name="meshapi-v1-map-data-links"),
-    path("mapdata/sectors/", views.MapDataSectorList.as_view(), name="meshapi-v1-map-data-sectors"),
+    path("mapdata/nodes/", views.map_data_node_list, name="meshapi-v1-map-data-installs"),
+    path("mapdata/links/", views.map_data_link_list, name="meshapi-v1-map-data-links"),
+    path("mapdata/sectors/", views.map_data_sector_list, name="meshapi-v1-map-data-sectors"),
     path("geography/whole-mesh.kml", views.WholeMeshKML.as_view(), name="meshapi-v1-geography-whole-mesh-kml"),
     path("update-panoramas/", views.update_panoramas, name="meshapi-v1-update-panoramas"),
 ]

--- a/src/meshapi/util/map_data.py
+++ b/src/meshapi/util/map_data.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Collection, List
 
+from cacheback.decorators import cacheback
 from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q, Subquery
 
 from meshapi.models import LOS, Device, Install, Link, Node, Sector
@@ -11,8 +12,10 @@ from meshapi.serializers import (
     MapDataLinkSerializer,
     MapDataSectorSerializer,
 )
+from meshdb.settings import MAP_DATA_CACHE_DURATION
 
 
+@cacheback(lifetime=MAP_DATA_CACHE_DURATION)
 def render_node_data() -> Collection[dict]:
     all_installs = []
 
@@ -108,6 +111,7 @@ def render_node_data() -> Collection[dict]:
     return all_installs_rendered_json + access_points
 
 
+@cacheback(lifetime=MAP_DATA_CACHE_DURATION)
 def render_link_data() -> Collection[dict]:
     all_links = []
     link_queryset = (
@@ -257,6 +261,7 @@ def render_link_data() -> Collection[dict]:
     return all_links
 
 
+@cacheback(lifetime=MAP_DATA_CACHE_DURATION)
 def render_sector_data() -> Collection[dict]:
     queryset = Sector.objects.filter(~Q(status__in=[Device.DeviceStatus.INACTIVE])).prefetch_related("node")
     return MapDataSectorSerializer(queryset, many=True).data

--- a/src/meshapi/util/map_data.py
+++ b/src/meshapi/util/map_data.py
@@ -1,0 +1,262 @@
+from datetime import datetime
+from typing import Collection, List
+
+from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q, Subquery
+
+from meshapi.models import LOS, Device, Install, Link, Node, Sector
+from meshapi.serializers import (
+    ALLOWED_INSTALL_STATUSES,
+    EXCLUDED_INSTALL_STATUSES,
+    MapDataInstallSerializer,
+    MapDataLinkSerializer,
+    MapDataSectorSerializer,
+)
+
+
+def render_node_data() -> Collection[dict]:
+    all_installs = []
+
+    queryset = (
+        Install.objects.select_related("building")
+        .select_related("node")
+        .prefetch_related("node__devices")
+        .filter(~Q(status__in=EXCLUDED_INSTALL_STATUSES))
+    )
+
+    for install in queryset:
+        all_installs.append(install)
+
+    # We need to make sure there is an entry on the map for every NN, and since we excluded the
+    # NN assigned rows in the query above, we need to go through the Node objects and
+    # include the nns we haven't already covered via install num
+    covered_nns = {install.install_number for install in all_installs}
+    for node in (
+        Node.objects.filter(~Q(status=Node.NodeStatus.INACTIVE) & Q(installs__status__in=ALLOWED_INSTALL_STATUSES))
+        .prefetch_related("devices")
+        .prefetch_related(
+            Prefetch(
+                "installs",
+                queryset=Install.objects.all().select_related("building"),
+                to_attr="prefetched_installs",
+            )
+        )
+        .prefetch_related(
+            Prefetch(
+                "installs",
+                queryset=Install.objects.filter(status=Install.InstallStatus.ACTIVE).select_related("building"),
+                to_attr="active_installs",
+            )
+        )
+    ):
+        if node.network_number not in covered_nns:
+            # Arbitrarily pick a representative install for the details of the "Fake" node,
+            # preferring active installs if possible
+            representative_install = (
+                node.active_installs  # type: ignore[attr-defined]
+                or node.prefetched_installs  # type: ignore[attr-defined]
+            )[0]
+
+            all_installs.append(
+                Install(
+                    install_number=node.network_number,
+                    node=node,
+                    status=Install.InstallStatus.NN_REASSIGNED
+                    if node.status == node.NodeStatus.ACTIVE
+                    else Install.InstallStatus.REQUEST_RECEIVED,
+                    building=representative_install.building,
+                    request_date=representative_install.request_date,
+                    roof_access=representative_install.roof_access,
+                ),
+            )
+            covered_nns.add(node.network_number)
+
+    all_installs.sort(key=lambda i: i.install_number)
+
+    all_installs_rendered_json = MapDataInstallSerializer(all_installs, many=True).data
+
+    access_points = []
+    for device in Device.objects.filter(
+        Q(status=Device.DeviceStatus.ACTIVE) & (~Q(node__latitude=F("latitude")) | ~Q(node__longitude=F("longitude")))
+    ):
+        install_date = (
+            int(
+                datetime.combine(
+                    device.install_date,
+                    datetime.min.time(),
+                ).timestamp()
+                * 1000
+            )
+            if device.install_date
+            else None
+        )
+        ap = {
+            "id": 1_000_000 + device.id,  # Hacky but we have no choice
+            "name": device.name,
+            "status": "Installed",
+            "coordinates": [device.longitude, device.latitude, None],
+            "roofAccess": False,
+            "notes": "AP",
+            "panoramas": [],
+        }
+
+        if install_date:
+            ap["requestDate"] = install_date
+            ap["installDate"] = install_date
+
+        access_points.append(ap)
+
+    return all_installs_rendered_json + access_points
+
+
+def render_link_data() -> Collection[dict]:
+    all_links = []
+    link_queryset = (
+        Link.objects.exclude(status__in=[Link.LinkStatus.INACTIVE])
+        .exclude(to_device__node__status=Node.NodeStatus.INACTIVE)
+        .exclude(from_device__node__status=Node.NodeStatus.INACTIVE)
+        .prefetch_related("to_device__node")
+        .prefetch_related("from_device__node")
+        .filter(
+            # This horrible monster query exists to de-duplicate links between the same node pairs
+            # so that the map doesn't freak out. These often exist because different devices on
+            # the same nodes can be linked. This deduplication happens somewhat arbitrarily
+            # and is borrowed from https://stackoverflow.com/a/69938289
+            pk__in=Link.objects.values("from_device__node__network_number", "to_device__node__network_number")
+            .distinct()
+            .annotate(
+                pk=Subquery(
+                    Link.objects.filter(
+                        from_device__node__network_number=OuterRef("from_device__node__network_number"),
+                        to_device__node__network_number=OuterRef("to_device__node__network_number"),
+                    )
+                    .order_by("pk")
+                    .values("pk")[:1]
+                )
+            )
+            .values_list("pk", flat=True)
+        )
+        # TODO: Possibly re-enable the below filters? They make make the map arguably more accurate,
+        #  but less consistent with the current one by removing links between devices that are
+        #  inactive in UISP
+        # .exclude(from_device__status=Device.DeviceStatus.INACTIVE)
+        # .exclude(to_device__status=Device.DeviceStatus.INACTIVE)
+    )
+
+    db_links_rendered_json = MapDataLinkSerializer(link_queryset, many=True).data
+    all_links.extend(db_links_rendered_json)
+
+    covered_links = {(link["from"], link["to"]) for link in all_links}
+
+    # Slightly hacky way to show ethernet cable runs on the old map.
+    # We just look for nodes where there are installs on separate buildings
+    # and add fake link objects to connect the installs on those other buildings to
+    # the node dot
+    cable_runs = []
+
+    for node in (
+        Node.objects.annotate(num_buildings=Count("buildings"))
+        .filter(num_buildings__gt=1)
+        .filter(~Q(status=Node.NodeStatus.INACTIVE) & Q(installs__status__in=ALLOWED_INSTALL_STATUSES))
+        .prefetch_related(
+            Prefetch(
+                "buildings__installs",
+                queryset=Install.objects.order_by("install_number").filter(status=Install.InstallStatus.ACTIVE),
+                to_attr="active_installs",
+            )
+        )
+    ):
+        for building in node.buildings.all():
+            active_installs = building.active_installs  # type: ignore[attr-defined]
+            if active_installs:
+                from_install = active_installs[0].install_number
+                if from_install != node.network_number:
+                    if (from_install, node.network_number) not in covered_links:
+                        cable_runs.append(
+                            {
+                                "from": from_install,
+                                "to": node.network_number,
+                                "status": "active",
+                            }
+                        )
+
+    all_links.extend(cable_runs)
+
+    # Since the old school map has no concept of a LOS, only potential Links, we need to
+    # create a fake potential Link object to represent each of our LOS entries
+    # For our purposes here, we only care about LOS entries between buildings that have
+    # install numbers. If one side of an LOS is a building that has no installs associated with
+    # it, we exclude it
+    los_objects_with_installs = (
+        LOS.objects.filter(
+            Exists(Install.objects.filter(building=OuterRef("from_building")))
+            & Exists(Install.objects.filter(building=OuterRef("to_building")))
+            & ~Q(from_building=F("to_building"))
+        )
+        .exclude(
+            # Remove any LOS objects that would duplicate Link objects,
+            # to avoid cluttering the map
+            Exists(
+                Link.objects.filter(
+                    (
+                        Q(from_device__node__buildings=OuterRef("from_building"))
+                        & Q(to_device__node__buildings=OuterRef("to_building"))
+                    )
+                    | (
+                        Q(from_device__node__buildings=OuterRef("to_building"))
+                        & Q(to_device__node__buildings=OuterRef("from_building"))
+                    )
+                )
+            )
+        )
+        .filter(
+            # This horrible monster query exists to de-duplicate LOSes between the same building
+            # pairs so that the map doesn't freak out. This deduplication happens somewhat
+            # arbitrarily and is borrowed from https://stackoverflow.com/a/69938289
+            pk__in=LOS.objects.values("from_building", "to_building")
+            .distinct()
+            .annotate(
+                pk=Subquery(
+                    LOS.objects.filter(
+                        from_building=OuterRef("from_building"),
+                        to_building=OuterRef("to_building"),
+                    )
+                    .order_by("pk")
+                    .values("pk")[:1]
+                )
+            )
+            .values_list("pk", flat=True)
+        )
+        .prefetch_related("from_building__installs")
+        .prefetch_related("from_building__nodes")
+        .prefetch_related("to_building__installs")
+        .prefetch_related("to_building__nodes")
+    )
+
+    los_based_potential_links = []
+    for los in los_objects_with_installs:
+        from_numbers = set(i.install_number for i in los.from_building.installs.all()).union(
+            set(n.network_number for n in los.from_building.nodes.all())
+        )
+
+        to_numbers = set(i.install_number for i in los.to_building.installs.all()).union(
+            set(n.network_number for n in los.to_building.nodes.all())
+        )
+
+        for from_number in from_numbers:
+            for to_number in to_numbers:
+                los_based_potential_links.append(
+                    {
+                        "from": from_number,
+                        "to": to_number,
+                        "status": Link.LinkStatus.PLANNED.lower(),
+                    }
+                )
+
+    all_links.extend(los_based_potential_links)
+
+    return all_links
+
+
+def render_sector_data() -> Collection[dict]:
+    queryset = Sector.objects.filter(~Q(status__in=[Device.DeviceStatus.INACTIVE])).prefetch_related("node")
+    return MapDataSectorSerializer(queryset, many=True).data

--- a/src/meshapi/util/map_data.py
+++ b/src/meshapi/util/map_data.py
@@ -75,9 +75,11 @@ def render_node_data() -> Collection[dict]:
 
     all_installs.sort(key=lambda i: i.install_number)
 
-    all_installs_rendered_json = MapDataInstallSerializer(all_installs, many=True).data
+    all_installs_rendered_json: List[dict] = MapDataInstallSerializer(  # type: ignore[assignment]
+        all_installs, many=True
+    ).data
 
-    access_points = []
+    access_points: List[dict] = []
     for device in Device.objects.filter(
         Q(status=Device.DeviceStatus.ACTIVE) & (~Q(node__latitude=F("latitude")) | ~Q(node__longitude=F("longitude")))
     ):
@@ -113,7 +115,7 @@ def render_node_data() -> Collection[dict]:
 
 @cacheback(lifetime=MAP_DATA_CACHE_DURATION)
 def render_link_data() -> Collection[dict]:
-    all_links = []
+    all_links: List[dict] = []
     link_queryset = (
         Link.objects.exclude(status__in=[Link.LinkStatus.INACTIVE])
         .exclude(to_device__node__status=Node.NodeStatus.INACTIVE)

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -7,6 +7,19 @@ from rest_framework.response import Response
 from meshapi.util.map_data import render_link_data, render_node_data, render_sector_data
 
 
+def should_request_bypass_cache(request: Request) -> bool:
+    """
+    Check if we should bypass cache for this request, by checking if the caller requested as such,
+    via the ?nocache=True parameter.
+    :param request: A DRF request object
+    :return: A boolean indicating if we should bypass cache for this request
+    """
+    if request.query_params.get("nocache") == "true":
+        return True
+
+    return False
+
+
 @extend_schema_view(
     get=extend_schema(
         tags=["Website Map Data"],
@@ -19,7 +32,7 @@ from meshapi.util.map_data import render_link_data, render_node_data, render_sec
 @api_view(["GET"])
 @permission_classes([permissions.AllowAny])
 def map_data_node_list(request: Request) -> Response:
-    node_data = render_node_data()
+    node_data = render_node_data(bypass_cache=should_request_bypass_cache(request))
     return Response(node_data)
 
 
@@ -34,7 +47,7 @@ def map_data_node_list(request: Request) -> Response:
 @api_view(["GET"])
 @permission_classes([permissions.AllowAny])
 def map_data_link_list(request: Request) -> Response:
-    link_data = render_link_data()
+    link_data = render_link_data(bypass_cache=should_request_bypass_cache(request))
     return Response(link_data)
 
 
@@ -49,5 +62,5 @@ def map_data_link_list(request: Request) -> Response:
 @api_view(["GET"])
 @permission_classes([permissions.AllowAny])
 def map_data_sector_list(request: Request) -> Response:
-    sector_data = render_sector_data()
+    sector_data = render_sector_data(bypass_cache=should_request_bypass_cache(request))
     return Response(sector_data)

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -1,20 +1,10 @@
-from datetime import datetime
-from typing import Any, Dict, List
-
-from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q, Subquery
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import generics, permissions
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from meshapi.models import LOS, Device, Install, Link, Node, Sector
-from meshapi.serializers import (
-    ALLOWED_INSTALL_STATUSES,
-    EXCLUDED_INSTALL_STATUSES,
-    MapDataInstallSerializer,
-    MapDataLinkSerializer,
-    MapDataSectorSerializer,
-)
+from meshapi.util.map_data import render_link_data, render_node_data, render_sector_data
 
 
 @extend_schema_view(
@@ -26,109 +16,11 @@ from meshapi.serializers import (
         "deprecated/removed in the future)",
     ),
 )
-class MapDataNodeList(generics.ListAPIView):
-    permission_classes = [permissions.AllowAny]
-    serializer_class = MapDataInstallSerializer
-    pagination_class = None
-
-    def get_queryset(self) -> List[Install]:  # type: ignore[override]
-        all_installs = []
-
-        queryset = (
-            Install.objects.select_related("building")
-            .select_related("node")
-            .prefetch_related("node__devices")
-            .filter(~Q(status__in=EXCLUDED_INSTALL_STATUSES))
-        )
-
-        for install in queryset:
-            all_installs.append(install)
-
-        # We need to make sure there is an entry on the map for every NN, and since we excluded the
-        # NN assigned rows in the query above, we need to go through the Node objects and
-        # include the nns we haven't already covered via install num
-        covered_nns = {install.install_number for install in all_installs}
-        for node in (
-            Node.objects.filter(~Q(status=Node.NodeStatus.INACTIVE) & Q(installs__status__in=ALLOWED_INSTALL_STATUSES))
-            .prefetch_related("devices")
-            .prefetch_related(
-                Prefetch(
-                    "installs",
-                    queryset=Install.objects.all().select_related("building"),
-                    to_attr="prefetched_installs",
-                )
-            )
-            .prefetch_related(
-                Prefetch(
-                    "installs",
-                    queryset=Install.objects.filter(status=Install.InstallStatus.ACTIVE).select_related("building"),
-                    to_attr="active_installs",
-                )
-            )
-        ):
-            if node.network_number not in covered_nns:
-                # Arbitrarily pick a representative install for the details of the "Fake" node,
-                # preferring active installs if possible
-                representative_install = (
-                    node.active_installs  # type: ignore[attr-defined]
-                    or node.prefetched_installs  # type: ignore[attr-defined]
-                )[0]
-
-                all_installs.append(
-                    Install(
-                        install_number=node.network_number,
-                        node=node,
-                        status=Install.InstallStatus.NN_REASSIGNED
-                        if node.status == node.NodeStatus.ACTIVE
-                        else Install.InstallStatus.REQUEST_RECEIVED,
-                        building=representative_install.building,
-                        request_date=representative_install.request_date,
-                        roof_access=representative_install.roof_access,
-                    ),
-                )
-                covered_nns.add(node.network_number)
-
-        all_installs.sort(key=lambda i: i.install_number)
-        return all_installs
-
-    def list(self, request: Request, *args: List[Any], **kwargs: Dict[str, Any]) -> Response:
-        response = super().list(request, args, kwargs)
-
-        access_points = []
-        for device in Device.objects.filter(
-            Q(status=Device.DeviceStatus.ACTIVE)
-            & (~Q(node__latitude=F("latitude")) | ~Q(node__longitude=F("longitude")))
-        ):
-            install_date = (
-                int(
-                    datetime.combine(
-                        device.install_date,
-                        datetime.min.time(),
-                    ).timestamp()
-                    * 1000
-                )
-                if device.install_date
-                else None
-            )
-            ap = {
-                "id": 1_000_000 + device.id,  # Hacky but we have no choice
-                "name": device.name,
-                "status": "Installed",
-                "coordinates": [device.longitude, device.latitude, None],
-                "roofAccess": False,
-                "notes": "AP",
-                "panoramas": [],
-            }
-
-            if install_date:
-                ap["requestDate"] = install_date
-                ap["installDate"] = install_date
-
-            access_points.append(ap)
-
-        response.data.extend(access_points)
-
-        return response
+@api_view(["GET"])
+@permission_classes([permissions.AllowAny])
+def map_data_node_list(request: Request) -> Response:
+    node_data = render_node_data()
+    return Response(node_data)
 
 
 @extend_schema_view(
@@ -139,155 +31,11 @@ class MapDataNodeList(generics.ListAPIView):
         "(Warning: This endpoint is a legacy format and may be deprecated/removed in the future)",
     ),
 )
-class MapDataLinkList(generics.ListAPIView):
-    permission_classes = [permissions.AllowAny]
-    serializer_class = MapDataLinkSerializer
-    pagination_class = None
-    queryset = (
-        Link.objects.exclude(status__in=[Link.LinkStatus.INACTIVE])
-        .exclude(to_device__node__status=Node.NodeStatus.INACTIVE)
-        .exclude(from_device__node__status=Node.NodeStatus.INACTIVE)
-        .prefetch_related("to_device__node")
-        .prefetch_related("from_device__node")
-        .filter(
-            # This horrible monster query exists to de-duplicate links between the same node pairs
-            # so that the map doesn't freak out. These often exist because different devices on
-            # the same nodes can be linked. This deduplication happens somewhat arbitrarily
-            # and is borrowed from https://stackoverflow.com/a/69938289
-            pk__in=Link.objects.values("from_device__node__network_number", "to_device__node__network_number")
-            .distinct()
-            .annotate(
-                pk=Subquery(
-                    Link.objects.filter(
-                        from_device__node__network_number=OuterRef("from_device__node__network_number"),
-                        to_device__node__network_number=OuterRef("to_device__node__network_number"),
-                    )
-                    .order_by("pk")
-                    .values("pk")[:1]
-                )
-            )
-            .values_list("pk", flat=True)
-        )
-        # TODO: Possibly re-enable the below filters? They make make the map arguably more accurate,
-        #  but less consistent with the current one by removing links between devices that are
-        #  inactive in UISP
-        # .exclude(from_device__status=Device.DeviceStatus.INACTIVE)
-        # .exclude(to_device__status=Device.DeviceStatus.INACTIVE)
-    )
-
-    def list(self, request: Request, *args: List[Any], **kwargs: Dict[str, Any]) -> Response:
-        response = super().list(request, *args, **kwargs)
-
-        covered_links = {(link["from"], link["to"]) for link in response.data}
-
-        # Slightly hacky way to show ethernet cable runs on the old map.
-        # We just look for nodes where there are installs on separate buildings
-        # and add fake link objects to connect the installs on those other buildings to
-        # the node dot
-        cable_runs = []
-
-        for node in (
-            Node.objects.annotate(num_buildings=Count("buildings"))
-            .filter(num_buildings__gt=1)
-            .filter(~Q(status=Node.NodeStatus.INACTIVE) & Q(installs__status__in=ALLOWED_INSTALL_STATUSES))
-            .prefetch_related(
-                Prefetch(
-                    "buildings__installs",
-                    queryset=Install.objects.order_by("install_number").filter(status=Install.InstallStatus.ACTIVE),
-                    to_attr="active_installs",
-                )
-            )
-        ):
-            for building in node.buildings.all():
-                active_installs = building.active_installs  # type: ignore[attr-defined]
-                if active_installs:
-                    from_install = active_installs[0].install_number
-                    if from_install != node.network_number:
-                        if (from_install, node.network_number) not in covered_links:
-                            cable_runs.append(
-                                {
-                                    "from": from_install,
-                                    "to": node.network_number,
-                                    "status": "active",
-                                }
-                            )
-
-        response.data.extend(cable_runs)
-
-        # Since the old school map has no concept of a LOS, only potential Links, we need to
-        # create a fake potential Link object to represent each of our LOS entries
-        # For our purposes here, we only care about LOS entries between buildings that have
-        # install numbers. If one side of an LOS is a building that has no installs associated with
-        # it, we exclude it
-        los_objects_with_installs = (
-            LOS.objects.filter(
-                Exists(Install.objects.filter(building=OuterRef("from_building")))
-                & Exists(Install.objects.filter(building=OuterRef("to_building")))
-                & ~Q(from_building=F("to_building"))
-            )
-            .exclude(
-                # Remove any LOS objects that would duplicate Link objects,
-                # to avoid cluttering the map
-                Exists(
-                    Link.objects.filter(
-                        (
-                            Q(from_device__node__buildings=OuterRef("from_building"))
-                            & Q(to_device__node__buildings=OuterRef("to_building"))
-                        )
-                        | (
-                            Q(from_device__node__buildings=OuterRef("to_building"))
-                            & Q(to_device__node__buildings=OuterRef("from_building"))
-                        )
-                    )
-                )
-            )
-            .filter(
-                # This horrible monster query exists to de-duplicate LOSes between the same building
-                # pairs so that the map doesn't freak out. This deduplication happens somewhat
-                # arbitrarily and is borrowed from https://stackoverflow.com/a/69938289
-                pk__in=LOS.objects.values("from_building", "to_building")
-                .distinct()
-                .annotate(
-                    pk=Subquery(
-                        LOS.objects.filter(
-                            from_building=OuterRef("from_building"),
-                            to_building=OuterRef("to_building"),
-                        )
-                        .order_by("pk")
-                        .values("pk")[:1]
-                    )
-                )
-                .values_list("pk", flat=True)
-            )
-            .prefetch_related("from_building__installs")
-            .prefetch_related("from_building__nodes")
-            .prefetch_related("to_building__installs")
-            .prefetch_related("to_building__nodes")
-        )
-
-        los_based_potential_links = []
-        for los in los_objects_with_installs:
-            from_numbers = set(i.install_number for i in los.from_building.installs.all()).union(
-                set(n.network_number for n in los.from_building.nodes.all())
-            )
-
-            to_numbers = set(i.install_number for i in los.to_building.installs.all()).union(
-                set(n.network_number for n in los.to_building.nodes.all())
-            )
-
-            for from_number in from_numbers:
-                for to_number in to_numbers:
-                    los_based_potential_links.append(
-                        {
-                            "from": from_number,
-                            "to": to_number,
-                            "status": Link.LinkStatus.PLANNED.lower(),
-                        }
-                    )
-
-        response.data.extend(los_based_potential_links)
-
-        return response
+@api_view(["GET"])
+@permission_classes([permissions.AllowAny])
+def map_data_link_list(request: Request) -> Response:
+    link_data = render_link_data()
+    return Response(link_data)
 
 
 @extend_schema_view(
@@ -298,8 +46,8 @@ class MapDataLinkList(generics.ListAPIView):
         "(Warning: This endpoint is a legacy format and may be deprecated/removed in the future)",
     ),
 )
-class MapDataSectorList(generics.ListAPIView):
-    permission_classes = [permissions.AllowAny]
-    serializer_class = MapDataSectorSerializer
-    pagination_class = None
-    queryset = Sector.objects.filter(~Q(status__in=[Device.DeviceStatus.INACTIVE])).prefetch_related("node")
+@api_view(["GET"])
+@permission_classes([permissions.AllowAny])
+def map_data_sector_list(request: Request) -> Response:
+    sector_data = render_sector_data()
+    return Response(sector_data)

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -219,6 +219,15 @@ STATICFILES_DIRS = [
     "/var/www/static/",
 ]
 
+MAP_DATA_CACHE_DURATION = 90  # seconds
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": "redis://localhost:6379/0",
+    }
+}
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 


### PR DESCRIPTION
This PR adds `django-cacheback` which allows the content of the map endpoints to be loaded asynchronously into redis for caching purposes. Then at request time, Django just pulls the JSON blob from Redis and serves it, saving expensive database calls
