### PR TITLE
Fix invalid codecov config to allow 90% coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,10 +1,9 @@
-codecov:
-  coverage:
-    status:
-      project:
-        default:
-          target: 90%
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
 
-      patch:
-        default:
-          target: 90%
+    patch:
+      default:
+        target: 90%


### PR DESCRIPTION
Whoops somehow the yaml was invalid, validated it's correct now with:

```
> curl --data-binary @.codecov.yml https://codecov.io/validate        
Valid!

{
  "coverage": {
    "status": {
      "project": {
        "default": {
          "target": 90.0
        }
      },
      "patch": {
        "default": {
          "target": 90.0
        }
      }
    }
  }
}

```