### PR TITLE
Add secret to helm chart

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -56,4 +56,5 @@ jobs:
         --set pgadmin.default_password="${{ secrets.PGADMIN_PASSWORD }}" \
         --set uisp.user="${{ secrets.UISP_USER }}" \
         --set uisp.psk="${{ secrets.UISP_PSK }}" \
+        --set meshweb.slack_webhook="${{ secrets.SLACK_ADMIN_NOTIFICATIONS_WEBHOOK_URL }}" \
         --set ingress.hosts[0].host="${{ vars.INGRESS_HOST }}",ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -141,6 +141,11 @@ spec:
                 secretKeyRef:
                   name: meshdb-secrets
                   key: uisp-pass
+            - name: SLACK_ADMIN_NOTIFICATIONS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: meshdb-secrets
+                  key: slack-webhook
             - name: ADMIN_MAP_BASE_URL
               valueFrom:
                 configMapKeyRef:

--- a/infra/helm/meshdb/templates/secrets.yaml
+++ b/infra/helm/meshdb/templates/secrets.yaml
@@ -15,3 +15,4 @@ data:
   pano-github-token: {{ .Values.meshweb.pano_github_token | b64enc | quote }}
   pgadmin-default-email: {{ .Values.pgadmin.default_email | b64enc | quote }}
   pgadmin-default-password: {{ .Values.pgadmin.default_password | b64enc | quote }}
+  slack-webhook: {{ .Values.meshweb.slack_webhook | b64enc | quote }}


### PR DESCRIPTION
Add `SLACK_ADMIN_NOTIFICATIONS_WEBHOOK_URL` secret to helm chart.

- [ ] Add the value to both environments in the GitHub UI