### PR TITLE
Use install number for NN if possible

### DIFF
--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -418,11 +418,22 @@ def network_number_assignment(request: Request) -> Response:
         nn_install.node = nn_building.primary_node
     else:
         # Otherwise, try to use the install number if it is a valid number and unused
+        #
+        # We also don't use the install number if the install status indicates the number has been
+        # re-used (even if it hasn't been according to the Node table). This shouldn't be common,
+        # but NN assignment is critical, so we want to be defensive in the case of incongruent
+        # database data. We could expand this list of "prohibited statuses" to align more closely
+        # with the logic used to determine the lowest NN, but that would mean refusing to give low
+        # installs their own (available) NN, just because the install was marked "pending". The
+        # reason for this logic mismatch really is so that we _can_ use it here, (i.e. we  didn't
+        # give their number out in get_next_available_network_number() because we are saving it
+        # specifically for use on their install)
         candidate_nn = nn_install.install_number
         if (
             candidate_nn < NETWORK_NUMBER_MIN
             or candidate_nn > NETWORK_NUMBER_MAX
             or len(Node.objects.filter(network_number=candidate_nn))
+            or nn_install.status in [Install.InstallStatus.NN_REASSIGNED, Install.InstallStatus.CLOSED]
         ):
             # If that doesn't work, lookup the lowest available number and use that
             try:

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -429,7 +429,7 @@ def network_number_assignment(request: Request) -> Response:
                 candidate_nn = get_next_available_network_number()
             except ValueError as exception:
                 return Response(
-                    {"detail": f"NN Request failed. {exception}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                    {"detail": f"NN Request failed. {exception.args[0]}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
                 )
 
         nn_install.node = Node(


### PR DESCRIPTION
Currently, if you put in an old install number, like `5001` to the NN form, MeshDB assigns a lower NN to that based on availability. This is likely confusing, since volunteers would expect `5001` to be used as the NN in this case since it is <8192. This PR adds a check for this case, and a test to cover both the case that `5001` has already been given out, and the case that it has not