### PR TITLE
Fix kubectl command

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -59,4 +59,4 @@ jobs:
         --set ingress.hosts[0].host="${{ vars.INGRESS_HOST }}",ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix
 
         # Rolling restart
-        kubectl -n ${{ vars.APP_NAMESPACE }} rollout restart deploy
+        kubectl --kubeconfig ./config --server https://${{ secrets.SSH_TARGET_IP }}:6443 -n ${{ vars.APP_NAMESPACE }} rollout restart deploy


### PR DESCRIPTION
Extra options are needed to point kubectl at the k3s api server because this is happening from the runner not the manager via ssh (as it was before).