### PR TITLE
Don't scan subcharts

### DIFF
--- a/.github/workflows/checkov.yaml
+++ b/.github/workflows/checkov.yaml
@@ -31,6 +31,7 @@ jobs:
           output_format: cli,sarif
           output_file_path: console,results.sarif
           download_external_modules: true
+          skip_path: infra/helm/meshdb/charts
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@d39d31e687223d841ef683f52467bd88e9b21c14 # v3


### PR DESCRIPTION
There is a bug in Checkov that seems to render helm subcharts separately, causing redundant checks to run (and fail). This will disable that until this issue gets addressed:

https://github.com/bridgecrewio/checkov/issues/6052