### PR TITLE
Add test case for apartment included in address line 1

### DIFF
--- a/src/meshapi/tests/sample_join_form_data.py
+++ b/src/meshapi/tests/sample_join_form_data.py
@@ -29,6 +29,37 @@ valid_join_form_submission = {
     },
 }
 
+valid_join_form_submission_with_apartment_in_address = {
+    "first_name": "John",
+    "last_name": "Smith",
+    "email": "jsmith@gmail.com",
+    "phone": "+1585-758-3425",
+    "street_address": "151 Broome St, Apt 1B",  # Apt shouldn't be here, but this example tests robustness
+    "parsed_street_address": "151 Broome Street",
+    "city": "New York",
+    "state": "NY",
+    "zip": 10002,
+    "apartment": "Apt 1B",
+    "roof_access": True,
+    "referral": "Googled it or something IDK",
+    "ncl": True,
+    "dob_addr_response": {
+        "features": [
+            {
+                "properties": {
+                    "housenumber": "151",
+                    "street": "Broome Street",
+                    "borough": "New York",
+                    "region_a": "NY",
+                    "postalcode": "10002",
+                    "addendum": {"pad": {"bin": 1077609}},
+                },
+                "geometry": {"coordinates": [0, 0]},
+            }
+        ]
+    },
+}
+
 valid_join_form_submission_no_email = {
     "first_name": "John",
     "last_name": "Smith",

--- a/src/meshapi/tests/test_join_form.py
+++ b/src/meshapi/tests/test_join_form.py
@@ -24,6 +24,7 @@ from .sample_join_form_data import (
     richmond_join_form_submission,
     valid_join_form_submission,
     valid_join_form_submission_no_email,
+    valid_join_form_submission_with_apartment_in_address,
 )
 from .util import TestThread
 
@@ -123,6 +124,7 @@ class TestJoinForm(TestCase):
             [kings_join_form_submission],
             [queens_join_form_submission],
             [bronx_join_form_submission],
+            [valid_join_form_submission_with_apartment_in_address],
         ]
     )
     def test_valid_join_form(self, submission):


### PR DESCRIPTION
Adds a test case for when the member shoves their apartment into address line 1. Had a shower thought that perhaps this would break things (it does in the existing google maps parser -> lat/lon -> BIN workflow that the spreadsheet uses). We appear to be immune to this failure though, so this test is just a regression to make sure it stays that way.

Note that here we are mocking out the call to the city API and assuming they continue to handle this case as we expect. Perhaps this case should be included in an integration test or a canary (#442 ?) so that we can validate this continues to be the case