### PR TITLE
Import script fixes

### DIFF
--- a/src/meshdb/utils/spreadsheet_import/parse_devices.py
+++ b/src/meshdb/utils/spreadsheet_import/parse_devices.py
@@ -7,16 +7,14 @@ from typing import List, Optional
 
 import django
 
-from meshapi.util.uisp_import.fetch_uisp import get_uisp_devices
-from meshapi.util.uisp_import.utils import parse_uisp_datetime
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "meshdb.settings")
 django.setup()
-
 
 import dateutil.parser
 
 from meshapi.models import AccessPoint, Device, Install, Node, Sector
+from meshapi.util.uisp_import.fetch_uisp import get_uisp_devices
+from meshapi.util.uisp_import.utils import parse_uisp_datetime
 from meshdb.utils.spreadsheet_import.csv_load import (
     SpreadsheetRow,
     SpreadsheetSector,
@@ -35,6 +33,11 @@ nn_subsitutions = {
 
 def find_uisp_device_with_ssid(devices: List[dict], ssid: str):
     for i, uisp_dev in enumerate(devices):
+        # We exclude 60Ghz sectors from SSID matching, since sometimes
+        # they have the same SSID as the 5 GHz ones and they can get confused
+        if uisp_dev["features"].get("has60GhzRadio"):
+            continue
+
         if uisp_dev["attributes"] and uisp_dev["attributes"].get("ssid") == ssid:
             return uisp_dev, i
 

--- a/src/meshdb/utils/spreadsheet_import/parse_link.py
+++ b/src/meshdb/utils/spreadsheet_import/parse_link.py
@@ -106,9 +106,11 @@ def get_representative_device_for_node(node: Node, link_status: SpreadsheetLinkS
         logging.warning(f"Creating mock device for NN{node.network_number}. Could not find any pre-existing devices")
         device = Device(
             node=node,
-            name=f"NN{node.network_number} Core",
+            name=f"NN{node.network_number} Placeholder Device",
             status=status,
-            notes=f"Automatically created to allow the import of spreadsheet links to/from NN{node.network_number}",
+            notes=f"Automatically created to allow the import of spreadsheet links to/from NN{node.network_number}. "
+            f"Please check the links connected to this device, and connect them to a more accurate device at this node "
+            f"(you may need to create these other devices in MeshDB or UISP first)",
         )
         device.save()
 

--- a/src/meshdb/utils/spreadsheet_import/parse_link.py
+++ b/src/meshdb/utils/spreadsheet_import/parse_link.py
@@ -109,8 +109,8 @@ def get_representative_device_for_node(node: Node, link_status: SpreadsheetLinkS
             name=f"NN{node.network_number} Placeholder Device",
             status=status,
             notes=f"Automatically created to allow the import of spreadsheet links to/from NN{node.network_number}. "
-            f"Please check the links connected to this device, and connect them to a more accurate device at this node "
-            f"(you may need to create these other devices in MeshDB or UISP first)",
+            "Please check the links connected to this device, and connect them to a more accurate device at this node "
+            "(you may need to create these other devices in MeshDB or UISP first)",
         )
         device.save()
 


### PR DESCRIPTION
Fixes an issue where 60 GHz sectors with the same SSID as 5GHz ones get imported instead, this was causing `nycmesh-3461-north` to not get imported correctly

Also rename "Core" to "Placeholder Device" to make it more clear that these devices are somewhat fake

Closes #239 