### PR TITLE
Make prod deploy after dev

### DIFF
--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -51,5 +51,5 @@ jobs:
     with:
       environment: prod
     secrets: inherit
-    needs: push_to_registry
+    needs: deploy_to_dev3
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
This makes it so we can drop tests in between and they won't try to run at the same time.