### PR TITLE
Bump meshweb to 3 replicas

### DIFF
--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "meshdb.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       {{- include "meshdb.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
It would be good to have 3 replicas of Meshweb running for HA purposes and to make deployments a little smoother. I have seen moments of unavailability on dev before that I would like to avoid. This is now possible because MeshDB is stateless.