### PR TITLE
Enable tracing for meshdb individually

### DIFF
--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        admission.datadoghq.com/python-lib.version: v2.11.2
+        admission.datadoghq.com/python-lib.version: v2.12
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        admission.datadoghq.com/python-lib.version: "2.12.2"
+        admission.datadoghq.com/python-lib.version: v2.11.2
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -12,8 +12,9 @@ spec:
       {{- include "meshdb.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        admission.datadoghq.com/python-lib.version: "2.12.2"
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
[Single-step instrumentation](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=kubernetes#specifying-at-the-service-level) is still a bit imprecise, so I'm going to switch back to specifying per-service tracing for now.