### PR TITLE
[celery] Change limits, tweak readiness, and convert to statefulset

### DIFF
--- a/infra/helm/meshdb/charts/celery/templates/deployment.yaml
+++ b/infra/helm/meshdb/charts/celery/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet 
+kind: StatefulSet
 metadata:
   name: {{ include "celery.fullname" . }}
   namespace: meshdb

--- a/infra/helm/meshdb/charts/celery/templates/deployment.yaml
+++ b/infra/helm/meshdb/charts/celery/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet 
 metadata:
   name: {{ include "celery.fullname" . }}
   namespace: meshdb

--- a/infra/helm/meshdb/charts/celery/values.yaml
+++ b/infra/helm/meshdb/charts/celery/values.yaml
@@ -26,11 +26,11 @@ ingress:
 
 resources:
   limits:
+    cpu: 1
+    memory: 512Mi
+  requests:
     cpu: 100m
     memory: 512Mi
-  #requests:
-  #  cpu: 100m
-  #  memory: 128Mi
 
 containers:
   - name: celery-worker
@@ -45,7 +45,7 @@ containers:
           - "sh"
           - "-c"
           - "python scripts/celery/probes/celery_liveness.py"
-      initialDelaySeconds: 30  # startup takes some time
+      initialDelaySeconds: 60  # startup takes some time
       periodSeconds: 60  # default is quite often and celery uses a lot cpu/ram then.
       timeoutSeconds: 10  # default is too low
     readinessProbe:
@@ -55,7 +55,7 @@ containers:
           - "sh"
           - "-c"
           - "python scripts/celery/probes/celery_readiness.py"
-      initialDelaySeconds: 30
+      initialDelaySeconds: 60
       periodSeconds: 60
       timeoutSeconds: 10
   - name: celery-beat
@@ -70,7 +70,7 @@ containers:
           - "sh"
           - "-c"
           - "python scripts/celery/probes/celery_beat_liveness.py"
-      initialDelaySeconds: 30
+      initialDelaySeconds: 60
       periodSeconds: 60
       timeoutSeconds: 10
     readinessProbe:
@@ -80,7 +80,7 @@ containers:
           - "sh"
           - "-c"
           - "python scripts/celery/probes/celery_beat_readiness.py"
-      initialDelaySeconds: 30
+      initialDelaySeconds: 60
       periodSeconds: 60
       timeoutSeconds: 10
 


### PR DESCRIPTION
What it says on the tin. I wanna do this to ensure that there's one and only one celery pod at a time.

https://stackoverflow.com/questions/68074742/can-a-deployment-ensure-that-there-is-never-more-than-one-pod-running

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/

