### PR TITLE
Fix: HTTP 500 on admin install add

### DIFF
--- a/src/meshapi/models/util/auto_incrementing_integer_field.py
+++ b/src/meshapi/models/util/auto_incrementing_integer_field.py
@@ -11,6 +11,9 @@ class Default(Expression):
     def as_sql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> Tuple[str, List[str | int]]:
         return "DEFAULT", []
 
+    def __str__(self):
+        return "-"
+
 
 class AutoIncrementingIntegerField(IntegerField):
     @property

--- a/src/meshapi/models/util/auto_incrementing_integer_field.py
+++ b/src/meshapi/models/util/auto_incrementing_integer_field.py
@@ -11,7 +11,7 @@ class Default(Expression):
     def as_sql(self, compiler: SQLCompiler, connection: BaseDatabaseWrapper) -> Tuple[str, List[str | int]]:
         return "DEFAULT", []
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "-"
 
 

--- a/src/meshapi/tests/test_admin_change_view.py
+++ b/src/meshapi/tests/test_admin_change_view.py
@@ -582,3 +582,31 @@ class TestAdminChangeView(TestCase):
         )
         self.assertEqual(building.primary_node, self.node1)
         self.assertEqual(list(building.nodes.all()), [self.node1])
+
+
+class TestAdminChangeView(TestCase):
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+        self.client.login(username="admin", password="admin_password")
+
+    def _call(self, route, code):
+        response = self.client.get(route)
+        self.assertEqual(code, response.status_code, f"Could not view {route} in the admin panel.")
+        return response
+
+    def test_add_views_http_200(self):
+        self._call("/admin/auth/group/add/", 200)
+        self._call("/admin/auth/user/add/", 200)
+        self._call("/admin/authtoken/tokenproxy/add/", 200)
+        self._call("/admin/meshapi_hooks/celeryserializerhook/add/", 200)
+        self._call("/admin/meshapi/building/add/", 200)
+        self._call("/admin/meshapi/member/add/", 200)
+        self._call("/admin/meshapi/install/add/", 200)
+        self._call("/admin/meshapi/link/add/", 200)
+        self._call("/admin/meshapi/los/add/", 200)
+        self._call("/admin/meshapi/sector/add/", 200)
+        self._call("/admin/meshapi/device/add/", 200)
+        self._call("/admin/meshapi/accesspoint/add/", 200)
+        self._call("/admin/meshapi/node/add/", 200)

--- a/src/meshapi/tests/test_admin_change_view.py
+++ b/src/meshapi/tests/test_admin_change_view.py
@@ -584,7 +584,7 @@ class TestAdminChangeView(TestCase):
         self.assertEqual(list(building.nodes.all()), [self.node1])
 
 
-class TestAdminChangeView(TestCase):
+class TestAdminAddView(TestCase):
     def setUp(self):
         self.admin_user = User.objects.create_superuser(
             username="admin", password="admin_password", email="admin@example.com"


### PR DESCRIPTION
Closes #548 

Also adds tests for HTTP 200 on the admin `/add` pages so that we catch something like this next time
