### PR TITLE
Add database default to dbrestore task

### DIFF
--- a/src/meshapi/tasks.py
+++ b/src/meshapi/tasks.py
@@ -46,7 +46,7 @@ def reset_dev_database() -> None:
 
     try:
         enable_flag("MAINTENANCE_MODE")
-        management.call_command("dbrestore", "--noinput")
+        management.call_command("dbrestore", "--noinput", "--database", "default")
         management.call_command("scramble_members", "--noinput")
         disable_flag("MAINTENANCE_MODE")
     except Exception as e:

--- a/src/meshapi/tests/test_tasks.py
+++ b/src/meshapi/tests/test_tasks.py
@@ -42,7 +42,7 @@ class TestResetDevDatabaseTask(TestCase):
         os.environ["AWS_SECRET_ACCESS_KEY"] = "alsofake"
         reset_dev_database()
         mock_call_command_func.assert_has_calls(
-            [mock.call("dbrestore", "--noinput"), mock.call("scramble_members", "--noinput")]
+            [mock.call("dbrestore", "--noinput", "--database", "default"), mock.call("scramble_members", "--noinput")]
         )
 
     @mock.patch("django.core.management.call_command")


### PR DESCRIPTION
After #542 , we need a new flag on dbrestore because we _technically_ have two databases now (or two roles), and dbrestore needs to know which one to use.