### PR TITLE
Don't show maintenance mode on swagger

### DIFF
--- a/src/meshweb/views.py
+++ b/src/meshweb/views.py
@@ -58,6 +58,7 @@ def maintenance(request: HttpRequest) -> HttpResponse:
     return HttpResponse(template.render(context, request))
 
 
+@extend_schema(exclude=True)  # Don't show on docs page
 @api_view(["POST"])
 @permission_classes([HasMaintenanceModePermission])
 def enable_maintenance(request: HttpRequest) -> HttpResponse:
@@ -70,6 +71,7 @@ def enable_maintenance(request: HttpRequest) -> HttpResponse:
     return HttpResponse(template.render(context, request))
 
 
+@extend_schema(exclude=True)  # Don't show on docs page
 @api_view(["POST"])
 @permission_classes([HasMaintenanceModePermission])
 def disable_maintenance(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
As mentioned in the linked issue, it's not prudent to display these internal "magic" routes on our swagger docs. Instead, I want to do that on the wiki or something.