### PR TITLE
Add new encrypted volume

### DIFF
--- a/infra/helm/meshdb/templates/postgres.yaml
+++ b/infra/helm/meshdb/templates/postgres.yaml
@@ -72,7 +72,7 @@ spec:
       volumes:
         - name: pg-data-vol
           persistentVolumeClaim:
-            claimName: {{ .Values.pg.pvc_name }}
+            claimName: {{ .Values.pg.pvc_name_legacy }}
       {{- with .Values.pg.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/meshdb/templates/postgres_pvc.yaml
+++ b/infra/helm/meshdb/templates/postgres_pvc.yaml
@@ -1,12 +1,25 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.pg.pvc_name }}
+  name: {{ .Values.pg.pvc_name_legacy }}
   namespace: {{ .Values.meshdb_app_namespace }}
 spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: longhorn
+  resources:
+    requests:
+      storage: {{ .Values.pg.pvc_size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.pg.pvc_name }}
+  namespace: {{ .Values.meshdb_app_namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-encrypted
   resources:
     requests:
       storage: {{ .Values.pg.pvc_size }}

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -7,7 +7,8 @@ pg:
   user: meshdb
   user_ro: meshdb_ro
   port: "5432"
-  pvc_name: "meshdb-postgres-pvc"
+  pvc_name_legacy: "meshdb-postgres-pvc"
+  pvc_name: "meshdb-postgres-encyrpted-pvc"
   pvc_size: "20Gi"
   liveness_probe: "true"
   podSecurityContext: {}


### PR DESCRIPTION
Add encrypted volume alongside current postgres volume to prep for maintenance event.

Related to https://github.com/nycmeshnet/meshdb/issues/343

Can be merged _after_:
- [x] Merge + deploy https://github.com/nycmeshnet/k8s-infra/pull/36