### PR TITLE
Add vars for "Add install-create event handlers"

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -69,6 +69,8 @@ jobs:
         --set meshweb.forms_url="${{ vars.FORMS_URL }}" \
         --set meshdb.site_base_url="${{ vars.SITE_BASE_URL }}" \
         --set meshweb.slack_webhook="${{ secrets.SLACK_ADMIN_NOTIFICATIONS_WEBHOOK_URL }}" \
+        --set meshweb.slack_join_webhook="${{ secrets.SLACK_JOIN_REQUESTS_CHANNEL_WEBHOOK_URL }}" \
+        --set meshweb.osticket_api_token="${{ secrets.OSTICKET_API_TOKEN }}" \
         --set meshweb.environment="${{ inputs.environment }}" \
         --set ingress.hosts[0].host="${{ vars.INGRESS_HOST }}",ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix \
         --set ingress.hosts[1].host="${{ vars.INGRESS_HOST_LEGACY }}",ingress.hosts[1].paths[0].path=/,ingress.hosts[1].paths[0].pathType=Prefix

--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -71,6 +71,7 @@ jobs:
         --set meshweb.slack_webhook="${{ secrets.SLACK_ADMIN_NOTIFICATIONS_WEBHOOK_URL }}" \
         --set meshweb.slack_join_webhook="${{ secrets.SLACK_JOIN_REQUESTS_CHANNEL_WEBHOOK_URL }}" \
         --set meshweb.osticket_api_token="${{ secrets.OSTICKET_API_TOKEN }}" \
+        --set meshweb.osticket_new_ticket_endpoint="${{ vars.OSTICKET_NEW_TICKET_ENDPOINT }}" \
         --set meshweb.environment="${{ inputs.environment }}" \
         --set ingress.hosts[0].host="${{ vars.INGRESS_HOST }}",ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix \
         --set ingress.hosts[1].host="${{ vars.INGRESS_HOST_LEGACY }}",ingress.hosts[1].paths[0].path=/,ingress.hosts[1].paths[0].pathType=Prefix

--- a/infra/helm/meshdb/templates/configmap.yaml
+++ b/infra/helm/meshdb/templates/configmap.yaml
@@ -37,3 +37,5 @@ data:
   FORMS_URL: {{ .Values.meshweb.forms_url | quote }}
 
   SITE_BASE_URL: {{ .Values.meshdb.site_base_url | quote }}
+
+  OSTICKET_NEW_TICKET_ENDPOINT: {{ .Values.meshweb.osticket_new_ticket_endpoint | quote }}

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -95,6 +95,16 @@ spec:
                 secretKeyRef:
                   name: meshdb-secrets
                   key: slack-webhook
+            - name: SLACK_JOIN_REQUESTS_CHANNEL_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: meshdb-secrets
+                  key: slack-join-webhook
+            - name: OSTICKET_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: meshdb-secrets
+                  key: osticket-api-token
           volumeMounts:
             - name: static-content-vol
               mountPath: /opt/meshdb/static

--- a/infra/helm/meshdb/templates/secrets.yaml
+++ b/infra/helm/meshdb/templates/secrets.yaml
@@ -16,3 +16,5 @@ data:
   uisp-pass: {{ .Values.uisp.psk | b64enc | quote }}
   pano-github-token: {{ .Values.meshweb.pano_github_token | b64enc | quote }}
   slack-webhook: {{ .Values.meshweb.slack_webhook | b64enc | quote }}
+  slack-join-webhook: {{ .Values.meshweb.slack_join_webhook | b64enc | quote }}
+  osticket-api-token: {{ .Values.meshweb.osticket_api_token | b64enc | quote }}


### PR DESCRIPTION
Add the env vars:
- `SLACK_JOIN_REQUESTS_CHANNEL_WEBHOOK_URL`
- `OSTICKET_API_TOKEN`

`OSTICKET_NEW_TICKET_ENDPOINT` is omitted, let me know if you can't live without it.

**The actual values, which I do not have, need to be added to the repo for CI**