### PR TITLE
Rolling restart stateful sets

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -75,3 +75,4 @@ jobs:
 
         # Rolling restart
         kubectl --kubeconfig ./config --server https://${{ secrets.SSH_TARGET_IP }}:6443 -n ${{ vars.APP_NAMESPACE }} rollout restart deploy
+        kubectl --kubeconfig ./config --server https://${{ secrets.SSH_TARGET_IP }}:6443 -n ${{ vars.APP_NAMESPACE }} rollout restart statefulset


### PR DESCRIPTION
Currently, changes are not being rolled out to stateful sets (celery). Fix this by bouncing them upon deployments.

This current age on prod (before I'm about to manually bounce it) is 6d2h days.