### PR TITLE
Only backup 'default'

### DIFF
--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -227,6 +227,7 @@ DBBACKUP_CONNECTORS = {
         "IF_EXISTS": True
     }
 }
+DBBACKUP_DATABASES = ["default"]
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
Only try to backup the "default" database, ignoring "readonly" which would be a subset of "default".

Resolves error:
```
pg_dump: error: query failed: ERROR:  permission denied for table django_migrations
```

Docs:
https://django-dbbackup.readthedocs.io/en/master/configuration.html#dbbackup-databases