### PR TITLE
Fix 500 on panorama building save (for real this time)

### DIFF
--- a/src/meshapi/tests/test_widgets.py
+++ b/src/meshapi/tests/test_widgets.py
@@ -8,8 +8,8 @@ class TestPanoramaViewer(TestCase):
         pass
 
     def test_pano_get_context(self):
-        PanoramaViewer.pano_get_context("test", "[\"blah\", \"blah2\"]")
+        PanoramaViewer.pano_get_context("test", '["blah", "blah2"]')
 
     def test_pano_get_context_bad_value(self):
-        PanoramaViewer.pano_get_context("test", 100) # type: ignore
-        PanoramaViewer.pano_get_context("test", None) # type: ignore
+        PanoramaViewer.pano_get_context("test", 100)  # type: ignore
+        PanoramaViewer.pano_get_context("test", None)  # type: ignore

--- a/src/meshapi/tests/test_widgets.py
+++ b/src/meshapi/tests/test_widgets.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+
+from meshapi.widgets import PanoramaViewer
+
+
+class TestPanoramaViewer(TestCase):
+    def setUp(self):
+        pass
+
+    def test_pano_get_context(self):
+        PanoramaViewer.pano_get_context("test", "[\"blah\", \"blah2\"]")
+
+    def test_pano_get_context_bad_value(self):
+        PanoramaViewer.pano_get_context("test", 100) # type: ignore
+        PanoramaViewer.pano_get_context("test", None) # type: ignore

--- a/src/meshapi/widgets.py
+++ b/src/meshapi/widgets.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any, Callable, Dict, Optional
 
 from django import forms
@@ -15,8 +16,13 @@ class PanoramaViewer(JSONFormWidget):
     def __init__(self, schema: dict):
         super().__init__(schema)
 
-    def pano_get_context(self, name: str, value: str = "[]") -> dict:
-        value_as_array = json.loads(value)
+    def pano_get_context(self, name: str, value: str) -> dict:
+        try:
+            value_as_array = json.loads(value) if value else ""
+        except TypeError:
+            logging.exception("Got bad value when trying to make panorama array.")
+            value_as_array = ""
+
         return {
             "widget": {
                 "name": name,

--- a/src/meshapi/widgets.py
+++ b/src/meshapi/widgets.py
@@ -16,7 +16,8 @@ class PanoramaViewer(JSONFormWidget):
     def __init__(self, schema: dict):
         super().__init__(schema)
 
-    def pano_get_context(self, name: str, value: str) -> dict:
+    @staticmethod
+    def pano_get_context(name: str, value: str) -> dict:
         try:
             value_as_array = json.loads(value) if value else ""
         except TypeError:


### PR DESCRIPTION
Finally managed to reproduce this locally (I believe with 293 Bainbridge St, which has no panos: (http://127.0.0.1:8000/admin/meshapi/building/0031a0dc-505d-4ba8-a124-170891c99bc7/change/))

So I added a guard to the JSON parsing logic that should fix this. I need to see if I can add a test, and codecov agrees T_T.