### PR TITLE
Fix: join form endpoint crashes due to custom serializer bug

### DIFF
--- a/src/meshapi/tests/test_slack_notification.py
+++ b/src/meshapi/tests/test_slack_notification.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
Whoops, UUID types are not trivially JSON serializable