### PR TITLE
Fix: map render crash due to Nodes without installs

### DIFF
--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -325,6 +325,45 @@ class TestViewsGetUnauthenticated(TestCase):
             )
         )
 
+        nodes.append(
+            Node(
+                network_number=9823,
+                status=Node.NodeStatus.ACTIVE,
+                latitude=40.724868,
+                longitude=-73.987881,
+            )
+        )
+        installs.append(
+            Install(
+                install_number=12381924,
+                status=Install.InstallStatus.PENDING,
+                request_date=datetime.date(2024, 1, 27),
+                roof_access=True,
+                building=buildings[-1],
+                node=nodes[-1],
+                member=member,
+            )
+        )
+
+        nodes.append(
+            Node(
+                network_number=9821,
+                status=Node.NodeStatus.ACTIVE,
+                latitude=40.724868,
+                longitude=-73.987881,
+            )
+        )
+
+        buildings.append(
+            Building(
+                address_truth_sources=[],
+                latitude=40.6962265,
+                longitude=-73.9917741,
+                altitude=66,
+                primary_node=nodes[-1],
+            )
+        )
+
         for node in nodes:
             node.save()
 
@@ -392,6 +431,22 @@ class TestViewsGetUnauthenticated(TestCase):
                     "panoramas": [],
                 },
                 {
+                    "coordinates": [-73.987881, 40.724868, None],
+                    "id": 9821,
+                    "panoramas": [],
+                    "requestDate": None,
+                    "roofAccess": True,
+                    "status": "NN assigned",
+                },
+                {
+                    "coordinates": [-73.987881, 40.724868, None],
+                    "id": 9823,
+                    "panoramas": [],
+                    "requestDate": 1706331600000,
+                    "roofAccess": True,
+                    "status": "NN assigned",
+                },
+                {
                     "id": 9999,
                     "status": "Installed",
                     "coordinates": [-73.9917741, 40.6962265, 66.0],
@@ -437,6 +492,14 @@ class TestViewsGetUnauthenticated(TestCase):
                     "requestDate": 1706331600000,
                     "panoramas": [],
                     "roofAccess": True,
+                },
+                {
+                    "coordinates": [-73.9917741, 40.6962265, 66.0],
+                    "id": 12381924,
+                    "panoramas": [],
+                    "requestDate": 1706331600000,
+                    "roofAccess": True,
+                    "status": "Interested",
                 },
                 {
                     "id": 1123456,

--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -364,6 +364,15 @@ class TestViewsGetUnauthenticated(TestCase):
             )
         )
 
+        nodes.append(
+            Node(
+                network_number=9820,
+                status=Node.NodeStatus.ACTIVE,
+                latitude=40.724868,
+                longitude=-73.987881,
+            )
+        )
+
         for node in nodes:
             node.save()
 
@@ -429,6 +438,14 @@ class TestViewsGetUnauthenticated(TestCase):
                     "requestDate": 1706331600000,
                     "roofAccess": True,
                     "panoramas": [],
+                },
+                {
+                    "coordinates": [-73.987881, 40.724868, None],
+                    "id": 9820,
+                    "panoramas": [],
+                    "requestDate": None,
+                    "roofAccess": True,
+                    "status": "NN assigned",
                 },
                 {
                     "coordinates": [-73.987881, 40.724868, None],

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -71,6 +71,7 @@ class MapDataNodeList(generics.ListAPIView):
             Node.objects.filter(~Q(status=Node.NodeStatus.INACTIVE))
             .prefetch_related("devices")
             .prefetch_related("installs")
+            .prefetch_related("buildings")
             .prefetch_related(
                 Prefetch(
                     "installs",
@@ -89,10 +90,13 @@ class MapDataNodeList(generics.ListAPIView):
             if node.network_number and node.network_number not in covered_nns:
                 # Arbitrarily pick a representative install for the details of the "Fake" node,
                 # preferring active installs if possible
-                representative_install = (
-                    node.active_installs  # type: ignore[attr-defined]
-                    or node.prefetched_installs  # type: ignore[attr-defined]
-                )[0]
+                try:
+                    representative_install = (
+                        node.active_installs  # type: ignore[attr-defined]
+                        or node.prefetched_installs  # type: ignore[attr-defined]
+                    )[0]
+                except IndexError:
+                    representative_install = None
 
                 all_installs.append(
                     Install(
@@ -101,9 +105,11 @@ class MapDataNodeList(generics.ListAPIView):
                         status=Install.InstallStatus.NN_REASSIGNED
                         if node.status == node.NodeStatus.ACTIVE
                         else Install.InstallStatus.REQUEST_RECEIVED,
-                        building=representative_install.building,
-                        request_date=representative_install.request_date,
-                        roof_access=representative_install.roof_access,
+                        building=representative_install.building if representative_install else node.buildings.first(),
+                        request_date=representative_install.request_date
+                        if representative_install
+                        else node.install_date,
+                        roof_access=representative_install.roof_access if representative_install else True,
                     ),
                 )
                 covered_nns.add(node.network_number)


### PR DESCRIPTION
Whoops, we introduced a bug in #606, this fixes the case where a Node has no installs and adds a regression test