### PR TITLE
Fix: zip code validation only applies to non-NYC addresses

### DIFF
--- a/src/meshdb/utils/spreadsheet_import/building/resolve_address.py
+++ b/src/meshdb/utils/spreadsheet_import/building/resolve_address.py
@@ -404,9 +404,6 @@ class AddressParser:
                 if not any(prop in r_addr for prop in ["city", "town", "village"]):
                     raise AddressError(f"Invalid address '{input_address}' - city/town/village not found in OSM data")
 
-                if pelias_zip_code_str and r_addr["postcode"].split("-")[0] != pelias_zip_code_str:
-                    raise AddressError(f"Mismatch between entered postal code and OSM result")
-
                 city, state = convert_osm_city_village_suburb_nonsense(r_addr)
 
                 result = AddressParsingResult(
@@ -423,6 +420,9 @@ class AddressParser:
                     ),
                     truth_sources=[AddressTruthSource.OSMNominatim],
                 )
+
+            if pelias_zip_code_str and result.address.zip_code.split("-")[0] != pelias_zip_code_str:
+                raise AddressError(f"Mismatch between entered postal code and validated address result")
         except AddressError:
             logging.debug(
                 f"Error locating '{input_address}'. Falling back to string parsing. "


### PR DESCRIPTION
The zip code validation applied in #604 only applies to non NYC addresses. We actually want to do this for all addresses, so that a mistaken address falls back to pelias parsing (slack thread with an example [here](https://nycmesh.slack.com/archives/C06GW3Q92TY/p1727772487337419))

This PR moves the logic to happen regardless of if we use OSM or the NYC DOB API to do the address validation