### PR TITLE
Only de-duplicate on primary email address

### DIFF
--- a/src/meshapi/tests/sample_join_form_data.py
+++ b/src/meshapi/tests/sample_join_form_data.py
@@ -60,37 +60,6 @@ valid_join_form_submission_with_apartment_in_address = {
     },
 }
 
-valid_join_form_submission_no_email = {
-    "first_name": "John",
-    "last_name": "Smith",
-    "email": None,
-    "phone": "+1585-758-3425",  # CSH's phone number :P
-    "street_address": "151 Broome St",  # Also covers New York County Test Case
-    "parsed_street_address": "151 Broome Street",
-    "city": "New York",
-    "state": "NY",
-    "zip": 10002,
-    "apartment": "",
-    "roof_access": True,
-    "referral": "Googled it or something IDK",
-    "ncl": True,
-    "dob_addr_response": {
-        "features": [
-            {
-                "properties": {
-                    "housenumber": "151",
-                    "street": "Broome Street",
-                    "borough": "New York",
-                    "region_a": "NY",
-                    "postalcode": "10002",
-                    "addendum": {"pad": {"bin": 1077609}},
-                },
-                "geometry": {"coordinates": [0, 0]},
-            }
-        ]
-    },
-}
-
 richmond_join_form_submission = {
     "first_name": "Maya",
     "last_name": "Viernes",

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -1,9 +1,7 @@
 import json
 import logging
-import operator
 from dataclasses import dataclass
 from datetime import date
-from functools import reduce
 from json.decoder import JSONDecodeError
 
 from django.db import IntegrityError, transaction
@@ -104,8 +102,8 @@ def join_form(request: Request) -> Response:
 
     join_form_full_name = f"{r.first_name} {r.last_name}"
 
-    if not r.email and not r.phone:
-        return Response({"detail": "Must provide an email or phone number"}, status=status.HTTP_400_BAD_REQUEST)
+    if not r.email:
+        return Response({"detail": "Must provide an email"}, status=status.HTTP_400_BAD_REQUEST)
 
     if r.email and not validate_email_address(r.email):
         return Response({"detail": f"{r.email} is not a valid email"}, status=status.HTTP_400_BAD_REQUEST)
@@ -134,29 +132,17 @@ def join_form(request: Request) -> Response:
             {"detail": "Your address could not be validated."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
 
-    # Check if there's an existing member. Group members by matching on both email and phone
-    # A member can have multiple install requests, if they move apartments for example
-    existing_member_filter_criteria = []
-    if r.email:
-        existing_member_filter_criteria.append(
-            Q(primary_email_address=r.email)
-            | Q(stripe_email_address=r.email)
-            | Q(additional_email_addresses__contains=[r.email])
-        )
-
-    if formatted_phone_number:
-        existing_member_filter_criteria.append(
-            Q(phone_number=formatted_phone_number) | Q(additional_phone_numbers=[formatted_phone_number])
-        )
-
-    existing_members = list(
-        Member.objects.filter(
-            reduce(
-                operator.or_,
-                existing_member_filter_criteria,
-            )
-        )
-    )
+    # A member can have multiple install requests, if they move apartments for example, so we
+    # check if there's an existing member. Group members by matching only on primary email address
+    # This is sublte but important. We do NOT want to dedupe on phone number, or even on additional
+    # email addresses at this time because this could lead to a situation where the email address
+    # entered in the join form does not match the email address we send the OSTicket to.
+    #
+    # That seems like a minor problem, but is actually a potential safety risk. Consider the case
+    # where a couple uses one person's email address to fill out the join form, but signs up for
+    # stripe payments with the other person's email address. If they then break up, and one person
+    # moves out, we definitely do not want to send an email with their new home address to their ex
+    existing_members = list(Member.objects.filter(Q(primary_email_address=r.email)))
 
     join_form_member = (
         existing_members[0]

--- a/src/meshdb/utils/spreadsheet_import/parse_member.py
+++ b/src/meshdb/utils/spreadsheet_import/parse_member.py
@@ -291,16 +291,8 @@ def get_or_create_member(
     )
 
     existing_member_filter_criteria = []
-    if len(other_emails) > 0:
-        existing_member_filter_criteria.extend(
-            Q(primary_email_address=email)
-            | Q(stripe_email_address=email)
-            | Q(additional_email_addresses__contains=[email])
-            for email in other_emails + ([stripe_email] if stripe_email else [])
-        )
-
-    if formatted_phone_number:
-        existing_member_filter_criteria.append(Q(phone_number=formatted_phone_number))
+    if len(primary_emails) > 0:
+        existing_member_filter_criteria.append(Q(primary_email_address=primary_emails[0]))
 
     existing_members = []
     if existing_member_filter_criteria:


### PR DESCRIPTION
Removes de-duplication on phone numbers and non-primary email addresses, as this creates some data integrity and safety concerns. We now only dedupe on the email address entered in the join form, which results in a noisier database, but is a safe and simple choice until we are able to better handle members without email addresses

Also re-enables the requirement that join form submissions include an email address

Closes #550