### PR TITLE
Add various HTTP headers to improve security

### DIFF
--- a/infra/helm/meshdb/templates/nginx_configmap.yaml
+++ b/infra/helm/meshdb/templates/nginx_configmap.yaml
@@ -20,9 +20,8 @@ data:
       location / {
         proxy_pass http://{{ include "meshdb.fullname" . }}-meshweb.{{ .Values.meshdb_app_namespace }}.svc.cluster.local:{{ .Values.meshweb.port }}/;
         proxy_set_header Host $host;
-        #proxy_set_header X-Real-IP $remote_addr;
-        #proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        #proxy_redirect off;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       }
     }
 

--- a/infra/helm/meshdb/templates/nginx_configmap.yaml
+++ b/infra/helm/meshdb/templates/nginx_configmap.yaml
@@ -20,7 +20,7 @@ data:
       location / {
         proxy_pass http://{{ include "meshdb.fullname" . }}-meshweb.{{ .Values.meshdb_app_namespace }}.svc.cluster.local:{{ .Values.meshweb.port }}/;
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "drf-hooks==0.1.3",
     "psycopg2-binary==2.9.*",
     "gunicorn==22.0.*",
+    "django-csp==3.*",
+    "django-permissions-policy==4.22.*",
     "python-dotenv==1.0.*",
     "stringcase==1.2.*",
     "python-dotenv==1.0.*",

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -59,7 +59,8 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
-CSP_STYLE_SRC = [
+CSP_REPORT_ONLY = True  # TODO: Set me to false https://github.com/nycmeshnet/meshdb/issues/644
+CSP_DEFAULT_SRC = [
     "'self'",
     "*.nycmesh.net",
     "maps.googleapis.com",

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from django.http.request import HttpRequest
 from dotenv import load_dotenv
@@ -71,7 +71,7 @@ CSP_DEFAULT_SRC = [
 
 # We don't use any of these advanced features, so be safe and disallow any scripts from
 # using them on our pages
-PERMISSIONS_POLICY = {
+PERMISSIONS_POLICY: Dict[str, List[str]] = {
     "accelerometer": [],
     "ambient-light-sensor": [],
     "autoplay": [],

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -53,8 +53,8 @@ FLAGS: Dict[str, Any] = {
 USE_X_FORWARDED_HOST = True
 
 SECURE_HSTS_SECONDS = 30  # TODO: Increase me to 31536000 https://github.com/nycmeshnet/meshdb/issues/642
-SECURE_HSTS_PRELOAD = True
-SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = False
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -67,6 +67,13 @@ CSP_DEFAULT_SRC = [
     "maps.gstatic.com",
     "fonts.googleapis.com",
     "fonts.gstatic.com",
+    "'unsafe-inline'",  # TODO: Remove me https://github.com/nycmeshnet/meshdb/issues/645
+    "*.browser-intake-datadoghq.com",
+]
+CSP_REPORT_URI = [
+    "https://csp-report.browser-intake-datadoghq.com/api/v2/logs"
+    "?dd-api-key=pubca00a94e49167539d2e291bea2b0f20f&dd-evp-origin=content-security-policy"
+    + f"&ddsource=csp-report&ddtags=service%3Ameshdb%2Cenv%3A{MESHDB_ENVIRONMENT}"
 ]
 
 # We don't use any of these advanced features, so be safe and disallow any scripts from

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -52,6 +52,43 @@ FLAGS: Dict[str, Any] = {
 
 USE_X_FORWARDED_HOST = True
 
+SECURE_HSTS_SECONDS = 30  # TODO: Increase me to 31536000 https://github.com/nycmeshnet/meshdb/issues/642
+SECURE_HSTS_PRELOAD = True
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+
+CSP_STYLE_SRC = [
+    "'self'",
+    "*.nycmesh.net",
+    "maps.googleapis.com",
+    "maps.gstatic.com",
+    "fonts.googleapis.com",
+    "fonts.gstatic.com",
+]
+
+# We don't use any of these advanced features, so be safe and disallow any scripts from
+# using them on our pages
+PERMISSIONS_POLICY = {
+    "accelerometer": [],
+    "ambient-light-sensor": [],
+    "autoplay": [],
+    "camera": [],
+    "display-capture": [],
+    "document-domain": [],
+    "encrypted-media": [],
+    "fullscreen": [],
+    "geolocation": [],
+    "gyroscope": [],
+    "interest-cohort": [],
+    "magnetometer": [],
+    "microphone": [],
+    "midi": [],
+    "payment": [],
+    "usb": [],
+}
+
 LOS_URL = os.environ.get("LOS_URL", "https://devlos.mesh.nycmesh.net")
 MAP_URL = os.environ.get("MAP_BASE_URL", "https://devmap.mesh.nycmesh.net")
 FORMS_URL = os.environ.get("FORMS_URL", "https://devforms.mesh.nycmesh.net")
@@ -118,6 +155,10 @@ if DEBUG:
         "http://127.0.0.1",
     ]
 
+    CSP_STYLE_SRC += [
+        "*",
+    ]
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -148,6 +189,8 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "django_permissions_policy.PermissionsPolicyMiddleware",
+    "csp.middleware.CSPMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -68,12 +68,12 @@ CSP_DEFAULT_SRC = [
     "fonts.googleapis.com",
     "fonts.gstatic.com",
     "'unsafe-inline'",  # TODO: Remove me https://github.com/nycmeshnet/meshdb/issues/645
-    "*.browser-intake-datadoghq.com",
+    "*.browser-intake-us5-datadoghq.com",
 ]
 CSP_REPORT_URI = [
-    "https://csp-report.browser-intake-datadoghq.com/api/v2/logs"
+    "https://csp-report.browser-intake-us5-datadoghq.com/api/v2/logs"
     "?dd-api-key=pubca00a94e49167539d2e291bea2b0f20f&dd-evp-origin=content-security-policy"
-    + f"&ddsource=csp-report&ddtags=service%3Ameshdb%2Cenv%3A{MESHDB_ENVIRONMENT}"
+    f"&ddsource=csp-report&ddtags=service%3Ameshdb%2Cenv%3A{MESHDB_ENVIRONMENT}"
 ]
 
 # We don't use any of these advanced features, so be safe and disallow any scripts from

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -156,7 +156,7 @@ if DEBUG:
         "http://127.0.0.1",
     ]
 
-    CSP_STYLE_SRC += [
+    CSP_DEFAULT_SRC += [
         "*",
     ]
 


### PR DESCRIPTION
Improve our security by following the HTTP header recommendations from the following resources:
- https://realpython.com/django-nginx-gunicorn/#incorporating-nginx
- https://securityheaders.com/?q=db.nycmesh.net%2Fadmin&followRedirects=on

Setting `X-Forwarded-Proto` also fixes a bug which caused a mixed content error on the changes from #636, since it fixes the value Django uses for `request.scheme` (currently set to `http` in prod due to the reverse proxy)