### PR TITLE
Break out healthcheck command

### DIFF
--- a/infra/helm/meshdb/templates/postgres.yaml
+++ b/infra/helm/meshdb/templates/postgres.yaml
@@ -43,6 +43,8 @@ spec:
           livenessProbe:
             exec:
               command:
+                - /bin/sh
+                - -c
                 - pg_isready -U ${DB_USER}
             periodSeconds: 5
             initialDelaySeconds: 5


### PR DESCRIPTION
Fix the healthcheck on the postgres container

```
Liveness probe errored: rpc error: code = Unknown desc = failed to exec in container: failed to start exec \"ff58be105b8b1a1d71643fc431edbce8ee38f76c8611855a51cdf3496f618817\": OCI runtime exec failed: exec failed: unable to start container process: exec: \"pg_isready -U ${DB_USER}\": executable file not found in $PATH: unknown\n \n _Events emitted by the kubelet seen at 2024-10-31 03:32:57 +0000 UTC since 2024-10-30 02:58:51 +0000 UTC_",
```