### PR TITLE
Add devices names to link.__str__ for "self links"

### DIFF
--- a/src/meshapi/models/link.py
+++ b/src/meshapi/models/link.py
@@ -78,8 +78,22 @@ class Link(models.Model):
     )
 
     def __str__(self) -> str:
-        if self.from_device.node.network_number and self.to_device.node.network_number:
-            return f"NN{self.from_device.node.network_number} → NN{self.to_device.node.network_number}"
+        from_name = None
+        to_name = None
+
+        if self.to_device.node == self.from_device.node:
+            from_name = self.from_device.name
+            to_name = self.to_device.name
+
+        if not from_name and self.from_device.node.network_number:
+            from_name = f"NN{self.from_device.node.network_number}"
+
+        if not to_name and self.to_device.node.network_number:
+            to_name = f"NN{self.to_device.node.network_number}"
+
+        if from_name and to_name:
+            return f"{from_name} ↔ {to_name}"
+
         return f"MeshDB Link ID {self.id}"
 
     @property

--- a/src/meshapi/tests/test_uisp_import.py
+++ b/src/meshapi/tests/test_uisp_import.py
@@ -1730,7 +1730,7 @@ class TestUISPImportHandlers(TransactionTestCase):
         new_los = LOS.objects.get(from_building=self.building1, to_building=self.building3)
         self.assertEqual(new_los.source, LOS.LOSSource.EXISTING_LINK)
         self.assertEqual(new_los.analysis_date, datetime.date.today())
-        self.assertEqual(new_los.notes, f"Created automatically from Link ID {self.link2.id} (NN1234 → NN9012)\n\n")
+        self.assertEqual(new_los.notes, f"Created automatically from Link ID {self.link2.id} (NN1234 ↔ NN9012)\n\n")
 
     def test_sync_same_building_link_with_los(self):
         self.device3b = Device(


### PR DESCRIPTION
This may be a bit controversial since it makes things a bit bulky at times, but looking at the string representations for "self links" in slack is very confusing.

`NN7489 -> NN7489` is so much more confusing than `nycmesh-7489-epr7 -> nycmesh-7489-north`

For now, we only include the device names for self-links (links between devices within a single node)

This heterogenous format does look a bit messy at times, but results in a lot more clarity for single links in isolation

![Screenshot 2024-11-09 at 18 48 45](https://github.com/user-attachments/assets/6d2942b6-9bec-4758-b177-30f22d857a39)

Also switches to a double headed arrow to indicate that links are not directional
