### PR TITLE
Silently update UISP ID when changed

### DIFF
--- a/src/meshapi/tests/test_uisp_import.py
+++ b/src/meshapi/tests/test_uisp_import.py
@@ -437,7 +437,6 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
         self.assertEqual(
             change_messages,
             [
-                "Changed UISP link ID to fake-uisp-uuid2",
                 "Changed connected device pair from [nycmesh-1234-dev1, nycmesh-5678-dev2] to [nycmesh-1234-dev1, nycmesh-9012-dev3]",
                 "Marked as Inactive due to it being offline in UISP for more than 30 days",
             ],
@@ -1529,7 +1528,6 @@ class TestUISPImportHandlers(TransactionTestCase):
 
         mock_notify_admins.assert_has_calls(
             [
-                call(self.link4, ["Changed UISP link ID to uisp-uuid40b"]),
                 call(self.link5b, ["Marked as Active due to it coming back online in UISP"]),
                 call(
                     self.link5a,

--- a/src/meshapi/util/uisp_import/update_objects.py
+++ b/src/meshapi/util/uisp_import/update_objects.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import List, Optional
 
 import requests
@@ -85,9 +86,10 @@ def update_link_from_uisp_data(
 
     if uisp_link_id != existing_link.uisp_id:
         existing_link.uisp_id = uisp_link_id
-        # TODO: Convert this to a log warning instead of an admin message if this fix holds
-        #  GH issue: https://github.com/nycmeshnet/meshdb/issues/691
-        change_messages.append(f"Changed UISP link ID to {uisp_link_id}")
+        logging.info(
+            f"Changed UISP link ID to {uisp_link_id} for {existing_link} link (ID {existing_link.id}). "
+            f"This is likely due to a UISP UUID rotation"
+        )
 
     uisp_device_pair = {uisp_to_device, uisp_from_device}
     db_device_pair = {existing_link.from_device, existing_link.to_device}


### PR DESCRIPTION
When UISP rotates the UUID of one of its links on us, and we detect it, no longer send a slack message. We opt instead to log an INFO message for transparency without being spammy. This is a follow up to the work done in #700. Here we completely silence the notification because the fix appears to be holding

Closes #691 