### PR TITLE
Add Stats Graph SVG Render View

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "django-sql-explorer==5.2.*",
     "django-simple-history==3.7.*",
     "prettytable==3.11.*",
+    "matplotlib==3.9.*",
 ]
 
 [project.optional-dependencies]
@@ -66,7 +67,8 @@ dev = [
     "djangorestframework-stubs[compatible-mypy]==3.15.*",
     "django-filter-stubs==0.1.3",
     "requests-mock==1.12.*",
-    "beautifulsoup4==4.12.*"
+    "beautifulsoup4==4.12.*",
+    "freezegun==1.5.1",
 ]
 
 [project.scripts]

--- a/src/meshapi/tests/test_join_form.py
+++ b/src/meshapi/tests/test_join_form.py
@@ -2,7 +2,7 @@ import copy
 import json
 import time
 from unittest import mock
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 import requests_mock
 from django.contrib.auth.models import User
@@ -14,7 +14,7 @@ from meshapi.models import Building, Install, Member, Node
 from meshapi.views import JoinFormRequest
 
 from ..serializers import MemberSerializer
-from ..validation import DOB_BUILDING_HEIGHT_API_URL, NYC_PLANNING_LABS_GEOCODE_URL
+from ..validation import DOB_BUILDING_HEIGHT_API_URL, NYC_PLANNING_LABS_GEOCODE_URL, NYCAddressInfo
 from .sample_data import sample_building, sample_node
 from .sample_join_form_data import (
     bronx_join_form_submission,
@@ -1076,8 +1076,11 @@ class TestJoinFormRaceCondition(TransactionTestCase):
         building = Building(**sample_building)
         building.save()
 
-    def test_valid_join_form(self):
+    @patch("meshapi.views.forms.geocode_nyc_address")
+    def test_valid_join_form(self, mock_geocode_func):
         results = []
+
+        mock_geocode_func.return_value = NYCAddressInfo("151 Broome Street", "Manhattan", "NY", "10002")
 
         member1_submission = valid_join_form_submission.copy()
         member1_submission["email_address"] = "member1@xyz.com"

--- a/src/meshapi/tests/test_meshweb.py
+++ b/src/meshapi/tests/test_meshweb.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+
+
+class TestViewsGetUnauthenticated(TestCase):
+    def test_landing_page_get_unauthenticated(self):
+        response = self.client.get("/")
+        self.assertEqual(
+            200,
+            response.status_code,
+            f"status code incorrect for /. Should be 200, but got {response.status_code}",
+        )

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -1,0 +1,90 @@
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from freezegun import freeze_time
+
+from meshapi.models import Building, Install, Member
+from meshapi.tests.sample_data import sample_building, sample_install, sample_member
+
+
+@freeze_time("2024-11-16")
+class TestWebsiteStats(TestCase):
+    def setUp(self):
+        self.sample_install_copy = sample_install.copy()
+        self.building_1 = Building(**sample_building)
+        self.building_1.save()
+
+        self.member = Member(**sample_member)
+        self.member.save()
+
+        self.install1 = Install(
+            **self.sample_install_copy,
+            building=self.building_1,
+            member=self.member,
+        )
+        self.install1.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install1.save()
+
+        self.install28 = Install(
+            **self.sample_install_copy,
+            install_number=28,
+            building=self.building_1,
+            member=self.member,
+        )
+        self.install28.save()
+
+    def test_empty_db(self):
+        self.install1.delete()
+        self.install28.delete()
+        svg_response = self.client.get("/website-embeds/stats-graph.svg")
+        self.assertContains(svg_response, "No installs found, is the database empty?", status_code=500)
+
+    def test_graph_svg_days_param(self):
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=0")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=5")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=7")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=28")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=31")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=300")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=365")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=-1")
+        self.assertEqual(svg_response.status_code, 400)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=abc")
+        self.assertEqual(svg_response.status_code, 400)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=0%2E0")
+        self.assertEqual(svg_response.status_code, 400)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=0.0")
+        self.assertEqual(svg_response.status_code, 400)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=0.")
+        self.assertEqual(svg_response.status_code, 400)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?days=.0")
+        self.assertEqual(svg_response.status_code, 400)
+
+    def test_graph_svg_data_param(self):
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?data=active_installs")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?data=install_requests")
+        self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?data=asdfadsf")
+        self.assertEqual(svg_response.status_code, 400)
+
+    def test_graph_svg_looks_roughly_right(self):
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?data=active_installs&days=365")
+        self.assertEqual(svg_response.status_code, 200)
+        self.assertContains(svg_response, "Active Installs")
+        self.assertContains(svg_response, ">1</text>")
+        self.assertContains(svg_response, ">Nov 17, 2023</text>")
+        self.assertContains(svg_response, ">Nov 16, 2024</text>")
+
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?data=install_requests&days=31")
+        self.assertEqual(svg_response.status_code, 200)
+        self.assertContains(svg_response, "Install Requests")
+        self.assertContains(svg_response, ">2</text>")
+        self.assertContains(svg_response, ">Oct 16, 2024</text>")
+        self.assertContains(svg_response, ">Nov 16, 2024</text>")

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -6,7 +6,7 @@ from meshapi.tests.sample_data import sample_building, sample_install, sample_me
 
 
 @freeze_time("2024-11-16")
-class TestWebsiteStats(TestCase):
+class TestWebsiteStatsGraph(TestCase):
     def setUp(self):
         self.sample_install_copy = sample_install.copy()
         self.building_1 = Building(**sample_building)
@@ -76,14 +76,91 @@ class TestWebsiteStats(TestCase):
     def test_graph_svg_looks_roughly_right(self):
         svg_response = self.client.get("/website-embeds/stats-graph.svg?data=active_installs&days=365")
         self.assertEqual(svg_response.status_code, 200)
-        self.assertContains(svg_response, "Active Installs")
         self.assertContains(svg_response, ">1</text>")
         self.assertContains(svg_response, ">Nov 17, 2023</text>")
         self.assertContains(svg_response, ">Nov 16, 2024</text>")
 
         svg_response = self.client.get("/website-embeds/stats-graph.svg?data=install_requests&days=31")
         self.assertEqual(svg_response.status_code, 200)
-        self.assertContains(svg_response, "Install Requests")
         self.assertContains(svg_response, ">2</text>")
         self.assertContains(svg_response, ">Oct 16, 2024</text>")
         self.assertContains(svg_response, ">Nov 16, 2024</text>")
+
+
+@freeze_time("2024-11-16")
+class TestWebsiteStatsJSON(TestCase):
+    def setUp(self):
+        self.sample_install_copy = sample_install.copy()
+        self.building_1 = Building(**sample_building)
+        self.building_1.save()
+
+        self.member = Member(**sample_member)
+        self.member.save()
+
+        self.install1 = Install(
+            **self.sample_install_copy,
+            building=self.building_1,
+            member=self.member,
+        )
+        self.install1.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install1.save()
+
+        self.install28 = Install(
+            **self.sample_install_copy,
+            install_number=28,
+            building=self.building_1,
+            member=self.member,
+        )
+        self.install28.save()
+
+    def test_empty_db(self):
+        self.install1.delete()
+        self.install28.delete()
+        response = self.client.get("/website-embeds/stats-graph.json")
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json(), {"error": "No installs found, is the database empty?"})
+
+    def test_days_param(self):
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=0")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=5")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=7")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=28")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=31")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=300")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=365")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=-1")
+        self.assertEqual(json_response.status_code, 400)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=abc")
+        self.assertEqual(json_response.status_code, 400)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=0%2E0")
+        self.assertEqual(json_response.status_code, 400)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=0.0")
+        self.assertEqual(json_response.status_code, 400)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=0.")
+        self.assertEqual(json_response.status_code, 400)
+        json_response = self.client.get("/website-embeds/stats-graph.json?days=.0")
+        self.assertEqual(json_response.status_code, 400)
+
+    def test_data_param(self):
+        json_response = self.client.get("/website-embeds/stats-graph.json?data=active_installs")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?data=install_requests")
+        self.assertEqual(json_response.status_code, 200)
+        json_response = self.client.get("/website-embeds/stats-graph.json?data=asdfadsf")
+        self.assertEqual(json_response.status_code, 400)
+
+    def test_json_data_is_correct(self):
+        json_response = self.client.get("/website-embeds/stats-graph.json?data=active_installs&days=365")
+        self.assertEqual(json_response.status_code, 200)
+        self.assertEqual(json_response.json(), {"data": [1] * 100, "start": 1700179200, "end": 1731715200})
+
+        json_response = self.client.get("/website-embeds/stats-graph.json?data=install_requests&days=31")
+        self.assertEqual(json_response.status_code, 200)
+        self.assertEqual(json_response.json(), {"data": [2] * 100, "start": 1729036800, "end": 1731715200})

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -1,5 +1,4 @@
-from django.contrib.auth.models import User
-from django.test import Client, TestCase
+from django.test import TestCase
 from freezegun import freeze_time
 
 from meshapi.models import Building, Install, Member

--- a/src/meshweb/urls.py
+++ b/src/meshweb/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path("maintenance/", views.maintenance, name="maintenance"),
     path("maintenance/enable/", views.enable_maintenance, name="maintenance-enable"),
     path("maintenance/disable/", views.disable_maintenance, name="maintenance-disable"),
+    path("website-embeds/stats-graph.svg", views.website_stats_graph, name="legacy-stats"),
     path("explorer/", include("explorer.urls")),
 ]

--- a/src/meshweb/urls.py
+++ b/src/meshweb/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("maintenance/", views.maintenance, name="maintenance"),
     path("maintenance/enable/", views.enable_maintenance, name="maintenance-enable"),
     path("maintenance/disable/", views.disable_maintenance, name="maintenance-disable"),
-    path("website-embeds/stats-graph.svg", views.website_stats_graph, name="legacy-stats"),
+    path("website-embeds/stats-graph.svg", views.website_stats_graph, name="legacy-stats-svg"),
+    path("website-embeds/stats-graph.json", views.website_stats_json, name="legacy-stats-json"),
     path("explorer/", include("explorer.urls")),
 ]

--- a/src/meshweb/views/__init__.py
+++ b/src/meshweb/views/__init__.py
@@ -1,0 +1,4 @@
+from .explorer_redirect import *
+from .index import *
+from .maintenance import *
+from .website_stats import *

--- a/src/meshweb/views/explorer_redirect.py
+++ b/src/meshweb/views/explorer_redirect.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.template import loader
+from django.urls import reverse
+from drf_spectacular.utils import extend_schema
+from flags.state import disable_flag, enable_flag, flag_enabled
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
+
+from meshapi.permissions import HasMaintenanceModePermission
+
+
+@api_view(["GET"])
+@permission_classes([permissions.AllowAny])
+def explorer_auth_redirect(request: HttpRequest) -> HttpResponse:
+    # Auth Redirect to ensure that behavior is consistent with admin panel
+    return HttpResponseRedirect("/admin/login/?next=/explorer/")

--- a/src/meshweb/views/explorer_redirect.py
+++ b/src/meshweb/views/explorer_redirect.py
@@ -1,17 +1,6 @@
-from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
-from django.template import loader
-from django.urls import reverse
-from drf_spectacular.utils import extend_schema
-from flags.state import disable_flag, enable_flag, flag_enabled
-from rest_framework import permissions
-from rest_framework.decorators import api_view, permission_classes
-
-from meshapi.permissions import HasMaintenanceModePermission
 
 
-@api_view(["GET"])
-@permission_classes([permissions.AllowAny])
-def explorer_auth_redirect(request: HttpRequest) -> HttpResponse:
+def explorer_auth_redirect(_: HttpRequest) -> HttpResponse:
     # Auth Redirect to ensure that behavior is consistent with admin panel
     return HttpResponseRedirect("/admin/login/?next=/explorer/")

--- a/src/meshweb/views/index.py
+++ b/src/meshweb/views/index.py
@@ -1,14 +1,8 @@
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.template import loader
-from drf_spectacular.utils import extend_schema
-from rest_framework import permissions
-from rest_framework.decorators import api_view, permission_classes
 
 
-@extend_schema(exclude=True)  # Don't show on docs page
-@api_view(["GET"])
-@permission_classes([permissions.AllowAny])
 def index(request: HttpRequest) -> HttpResponse:
     template = loader.get_template("meshweb/index.html")
     links = {

--- a/src/meshweb/views/index.py
+++ b/src/meshweb/views/index.py
@@ -1,0 +1,34 @@
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.template import loader
+from drf_spectacular.utils import extend_schema
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
+
+
+@extend_schema(exclude=True)  # Don't show on docs page
+@api_view(["GET"])
+@permission_classes([permissions.AllowAny])
+def index(request: HttpRequest) -> HttpResponse:
+    template = loader.get_template("meshweb/index.html")
+    links = {
+        "Member Tools": [
+            (f"{settings.FORMS_URL}/join/", "Join Form"),
+            (settings.LOS_URL, "Line of Sight Tool"),
+            (settings.MAP_URL, "Map"),
+        ],
+        "Volunteer Tools": [
+            ("/admin", "Admin Panel"),
+            ("/api/v1/geography/whole-mesh.kml", "KML Download"),
+            ("/explorer/play", "SQL Explorer"),
+            (settings.FORMS_URL, "Other Forms"),
+        ],
+        "Developer Tools": [
+            ("https://github.com/nycmeshnet/meshdb", "Source Code"),
+            ("/api/v1/", "MeshDB Data API"),
+            ("/api-docs/swagger/", "API Documentation (Swagger)"),
+            ("/api-docs/redoc/", "API Documentation (Redoc)"),
+        ],
+    }
+    context = {"links": links}
+    return HttpResponse(template.render(context, request))

--- a/src/meshweb/views/maintenance.py
+++ b/src/meshweb/views/maintenance.py
@@ -10,42 +10,6 @@ from rest_framework.decorators import api_view, permission_classes
 from meshapi.permissions import HasMaintenanceModePermission
 
 
-# Home view
-@extend_schema(exclude=True)  # Don't show on docs page
-@api_view(["GET"])
-@permission_classes([permissions.AllowAny])
-def index(request: HttpRequest) -> HttpResponse:
-    template = loader.get_template("meshweb/index.html")
-    links = {
-        "Member Tools": [
-            (f"{settings.FORMS_URL}/join/", "Join Form"),
-            (settings.LOS_URL, "Line of Sight Tool"),
-            (settings.MAP_URL, "Map"),
-        ],
-        "Volunteer Tools": [
-            ("/admin", "Admin Panel"),
-            ("/api/v1/geography/whole-mesh.kml", "KML Download"),
-            ("/explorer/play", "SQL Explorer"),
-            (settings.FORMS_URL, "Other Forms"),
-        ],
-        "Developer Tools": [
-            ("https://github.com/nycmeshnet/meshdb", "Source Code"),
-            ("/api/v1/", "MeshDB Data API"),
-            ("/api-docs/swagger/", "API Documentation (Swagger)"),
-            ("/api-docs/redoc/", "API Documentation (Redoc)"),
-        ],
-    }
-    context = {"links": links}
-    return HttpResponse(template.render(context, request))
-
-
-@api_view(["GET"])
-@permission_classes([permissions.AllowAny])
-def explorer_auth_redirect(request: HttpRequest) -> HttpResponse:
-    # Auth Redirect to ensure that behavior is consistent with admin panel
-    return HttpResponseRedirect("/admin/login/?next=/explorer/")
-
-
 @permission_classes([permissions.AllowAny])
 def maintenance(request: HttpRequest) -> HttpResponse:
     if not flag_enabled("MAINTENANCE_MODE"):

--- a/src/meshweb/views/maintenance.py
+++ b/src/meshweb/views/maintenance.py
@@ -1,16 +1,13 @@
-from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template import loader
 from django.urls import reverse
 from drf_spectacular.utils import extend_schema
 from flags.state import disable_flag, enable_flag, flag_enabled
-from rest_framework import permissions
 from rest_framework.decorators import api_view, permission_classes
 
 from meshapi.permissions import HasMaintenanceModePermission
 
 
-@permission_classes([permissions.AllowAny])
 def maintenance(request: HttpRequest) -> HttpResponse:
     if not flag_enabled("MAINTENANCE_MODE"):
         return HttpResponseRedirect(reverse("main"))

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -1,0 +1,200 @@
+import datetime
+import io
+import math
+
+import matplotlib.pyplot as plt
+import matplotlib.transforms
+import numpy as np
+from django.db.models import Min
+from django.http import HttpResponse
+from matplotlib import ticker
+
+from meshapi.models import Install
+
+# Make the SVG output include text instead of strokes
+plt.rcParams["svg.fonttype"] = "none"
+
+VALID_DATA_MODES = ["install_requests", "active_installs"]
+
+
+def website_stats_graph(request):
+    """
+    Renders an SVG graph for embedding on the website, showing install growth over time
+
+    Accepts two optional HTTP GET Params:
+     days - an integer representing the number of days prior to the current date to render graphs for (default: "all")
+     data - the data mode to use, either "install_requests" or "active_installs" (default: "install_requests")
+
+    Returns HTTP 400 with a plain text description of the error if anything is wrong with these
+    params, otherwise HTTP 200 with the response content being an SVG XML which is ready for browser
+    embedding and display
+    """
+    try:
+        days = int(request.GET.get("days", 0))
+        if days < 0:
+            raise ValueError()
+    except ValueError as e:
+        return HttpResponse(status=400, content="Invalid number of days to aggregate data for")
+
+    data_source = request.GET.get("data", "install_requests")
+    if data_source not in VALID_DATA_MODES:
+        return HttpResponse(status=400, content=f"Invalid data mode param, expecting one of: {VALID_DATA_MODES}")
+
+    if Install.objects.count() == 0:
+        return HttpResponse(
+            status=500,
+            content='<svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" '
+            + 'width="432pt" height="270pt" '
+            + 'viewBox="-10 -20 500 20" '
+            + 'version="1.1">'
+            + "<text>No installs found, is the database empty?</text>"
+            + "</svg>",
+            content_type="image/svg+xml",
+        )
+
+    intervals = 100
+    buckets = [0 for _ in range(intervals)]
+
+    if days > 0:
+        start_time = datetime.datetime.now() - datetime.timedelta(days=days)
+    else:
+        # "All" Case
+        start_time = datetime.datetime.combine(
+            Install.objects.all().aggregate(Min("request_date"))["request_date__min"],
+            datetime.datetime.min.time(),
+        )
+    end_time = datetime.datetime.now()
+    total_duration = end_time - start_time
+    total_duration_seconds = total_duration.total_seconds()
+
+    base_object_queryset = Install.objects.all()
+
+    if data_source == "active_installs":
+        # FYI This logic doesn't account for installs that have been abandoned,
+        # so it definitely underestimates historical values
+        base_object_queryset = base_object_queryset.filter(status=Install.InstallStatus.ACTIVE)
+        object_queryset = base_object_queryset.filter(
+            install_date__gte=start_time.date(),
+            install_date__lte=end_time.date(),
+        )
+        buckets[0] = base_object_queryset.filter(install_date__lt=start_time).count()
+    else:
+        object_queryset = base_object_queryset.filter(
+            request_date__gte=start_time.date(),
+            request_date__lte=end_time.date(),
+        )
+        buckets[0] = base_object_queryset.filter(request_date__lt=start_time).count()
+
+    for install in object_queryset:
+        if data_source == "active_installs":
+            counting_date = install.install_date or install.request_date
+        else:
+            counting_date = install.request_date
+
+        relative_seconds = (counting_date - start_time.date()).total_seconds()
+        bucket_index = math.floor((relative_seconds / total_duration_seconds) * intervals)
+        buckets[bucket_index] += 1
+
+    # Make cumulative
+    for i in range(intervals):
+        if i > 0:
+            buckets[i] += buckets[i - 1]
+
+    plt.figure()
+    x = np.arange(0, intervals, 1)
+    y = buckets
+
+    fig, ax = plt.subplots(figsize=(6, 3.75))
+
+    title_color = "#ff3a30" if data_source == "active_installs" else "#777"
+    titlefont = {
+        "family": "Helvetica Neue",
+        "weight": "bold",
+        "size": 15,
+        "color": title_color,
+    }
+
+    plt.suptitle(
+        "Active Installs" if data_source == "active_installs" else "Install Requests",
+        fontsize=12,
+        fontweight="bold",
+        fontfamily="Helvetica Neue",
+        horizontalalignment="left",
+        x=0.155,
+    )
+    ax.set_title(
+        "{x:,.0f}".format(x=buckets[-1]),
+        ha="left",
+        pad=10,
+        fontdict=titlefont,
+        x=0.04,
+    )
+
+    plot_color = "#ff3a30" if data_source == "active_installs" else "#aaaaaa"
+    ax.plot(y, color=plot_color)
+    ax.fill_between(x, y, 0, alpha=0.125, color=plot_color)
+
+    if total_duration < datetime.timedelta(days=366):
+        if total_duration < datetime.timedelta(days=8):
+            vertical_divisions = 7
+        elif total_duration < datetime.timedelta(days=32):
+            vertical_divisions = 4
+        else:
+            vertical_divisions = 12
+
+        ax.minorticks_on()
+        ax.xaxis.set_minor_locator(ticker.MultipleLocator((intervals - 1) / vertical_divisions))
+
+    plt.grid(which="minor", axis="x", color="#eeeeee", linewidth=1)
+
+    ax.set_xticklabels([])
+    ax.set_xticks([])
+    ax.set_yticks([buckets[0], buckets[-1]])
+    ax.tick_params(axis="both", which="both", length=0)
+
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["bottom"].set_visible(False)
+    ax.spines["left"].set_visible(False)
+
+    ax.set_ylim((buckets[0], buckets[-1]))
+    ax.yaxis.tick_right()
+    ax.tick_params(
+        axis="both",
+        which="both",
+        labelcolor="#777",
+        length=0,
+        labelsize=9,
+        pad=-8,
+        labelfontfamily="Helvetica Neue",
+    )
+    ax.yaxis.set_major_formatter(ticker.StrMethodFormatter("{x:,.0f}"))
+
+    ax2 = ax.secondary_xaxis("bottom")
+    ax2.set_xticklabels(
+        [
+            start_time.date().strftime("%b %-d, %Y"),
+            end_time.date().strftime("%b %-d, %Y"),
+        ],
+        position=(-1, -100),
+    )
+    ax2.set_ticks([8, intervals - 8])
+    ax2.tick_params(
+        axis="both",
+        which="both",
+        labelcolor="#777",
+        length=0,
+        labelsize=9,
+        pad=10,
+        labelfontfamily="Helvetica Neue",
+    )
+
+    ax2.spines["top"].set_visible(False)
+    ax2.spines["bottom"].set_visible(False)
+
+    plt.subplots_adjust(top=0.84)
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format="svg")
+
+    return HttpResponse(buf.getvalue(), content_type="image/svg+xml")

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -144,7 +144,7 @@ def render_graph(
         ],
         position=(-1, -GRAPH_X_AXIS_DATAPOINT_COUNT),
     )
-    ax2.set_ticks([int(GRAPH_X_AXIS_DATAPOINT_COUNT * 0.08), int(GRAPH_X_AXIS_DATAPOINT_COUNT * 0.92)])
+    ax2.set_ticks([int(GRAPH_X_AXIS_DATAPOINT_COUNT * 0.09), int(GRAPH_X_AXIS_DATAPOINT_COUNT * 0.89)])
     ax2.tick_params(
         axis="both",
         which="both",

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -27,7 +27,7 @@ matplotlib_lock = threading.Lock()
 
 
 @receiver(check_request_enabled)
-def cors_allow_website_stats_to_all(sender, request, **kwargs):
+def cors_allow_website_stats_to_all(sender: None, request: HttpRequest, **kwargs: dict) -> bool:
     """
     This handler adds an allow all CORS header to the stats endpoints, this should be totally safe since
     these endpoints don't modify any data (and images are exempt from CORS anyway)

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -3,10 +3,9 @@ import io
 import math
 
 import matplotlib.pyplot as plt
-import matplotlib.transforms
 import numpy as np
 from django.db.models import Min
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from matplotlib import ticker
 
 from meshapi.models import Install
@@ -17,7 +16,7 @@ plt.rcParams["svg.fonttype"] = "none"
 VALID_DATA_MODES = ["install_requests", "active_installs"]
 
 
-def website_stats_graph(request):
+def website_stats_graph(request: HttpRequest) -> HttpResponse:
     """
     Renders an SVG graph for embedding on the website, showing install growth over time
 
@@ -33,7 +32,7 @@ def website_stats_graph(request):
         days = int(request.GET.get("days", 0))
         if days < 0:
             raise ValueError()
-    except ValueError as e:
+    except ValueError:
         return HttpResponse(status=400, content="Invalid number of days to aggregate data for")
 
     data_source = request.GET.get("data", "install_requests")

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -1,12 +1,12 @@
 import datetime
 import io
 import math
+import re
 import threading
 from typing import List, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
-import regex
 from corsheaders.signals import check_request_enabled
 from django.db.models import Min
 from django.dispatch import receiver
@@ -40,7 +40,7 @@ def cors_allow_website_stats_to_all(sender: None, request: HttpRequest, **kwargs
         return False
 
     host = request.get_host()
-    if regex.match(r"deploy-preview-\d{1,5}--nycmesh-website\.netlify\.app", host):
+    if re.fullmatch(r"deploy-preview-\d{1,5}--nycmesh-website\.netlify\.app", host):
         return True
 
     if host in ["nycmesh.net", "www.nycmesh.net"]:

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -16,6 +16,14 @@ plt.rcParams["svg.fonttype"] = "none"
 VALID_DATA_MODES = ["install_requests", "active_installs"]
 
 
+def compute_graph_stats():
+    pass
+
+
+def render_graph():
+    pass
+
+
 def website_stats_graph(request: HttpRequest) -> HttpResponse:
     """
     Renders an SVG graph for embedding on the website, showing install growth over time
@@ -105,30 +113,6 @@ def website_stats_graph(request: HttpRequest) -> HttpResponse:
 
     fig, ax = plt.subplots(figsize=(6, 3.75))
 
-    title_color = "#ff3a30" if data_source == "active_installs" else "#777"
-    titlefont = {
-        "family": "Helvetica Neue",
-        "weight": "bold",
-        "size": 15,
-        "color": title_color,
-    }
-
-    plt.suptitle(
-        "Active Installs" if data_source == "active_installs" else "Install Requests",
-        fontsize=12,
-        fontweight="bold",
-        fontfamily="Helvetica Neue",
-        horizontalalignment="left",
-        x=0.155,
-    )
-    ax.set_title(
-        "{x:,.0f}".format(x=buckets[-1]),
-        ha="left",
-        pad=10,
-        fontdict=titlefont,
-        x=0.04,
-    )
-
     plot_color = "#ff3a30" if data_source == "active_installs" else "#aaaaaa"
     ax.plot(y, color=plot_color)
     ax.fill_between(x, y, 0, alpha=0.125, color=plot_color)
@@ -163,7 +147,7 @@ def website_stats_graph(request: HttpRequest) -> HttpResponse:
         which="both",
         labelcolor="#777",
         length=0,
-        labelsize=9,
+        labelsize=12,
         pad=-8,
         labelfontfamily="Helvetica Neue",
     )
@@ -183,7 +167,7 @@ def website_stats_graph(request: HttpRequest) -> HttpResponse:
         which="both",
         labelcolor="#777",
         length=0,
-        labelsize=9,
+        labelsize=12,
         pad=10,
         labelfontfamily="Helvetica Neue",
     )
@@ -191,7 +175,7 @@ def website_stats_graph(request: HttpRequest) -> HttpResponse:
     ax2.spines["top"].set_visible(False)
     ax2.spines["bottom"].set_visible(False)
 
-    plt.subplots_adjust(top=0.84)
+    plt.tight_layout()
 
     buf = io.BytesIO()
     plt.savefig(buf, format="svg")


### PR DESCRIPTION
Adds an endpoint to render SVG files for the website to display, in the style of the current [nycmesh.net/stats](https://nycmesh.net/stats) page

Also does a bit of refactoring and cleanup in meshweb, we should probably spread the views out into multiple files, and we don't need to use the DRF decorators for non-API views