### PR TITLE
Fix formatting on UISP import notification slack messages

### DIFF
--- a/src/meshapi/tests/test_uisp_import.py
+++ b/src/meshapi/tests/test_uisp_import.py
@@ -273,10 +273,9 @@ class TestUISPImportUtils(TestCase):
         mock_notify.assert_called_once_with(
             [device],
             DeviceSerializer,
-            message="modified device based on information from UISP. The following changes were made:\n"
+            message="*modified device based on information from UISP*. The following changes were made:\n"
             " - Mock change 1\n"
-            " - Mock change 2\n"
-            "(to prevent this, make changes to these fields in UISP rather than directly in MeshDB)",
+            " - Mock change 2\n",
         )
 
     @patch("meshapi.util.uisp_import.utils.notify_administrators_of_data_issue")
@@ -304,7 +303,7 @@ class TestUISPImportUtils(TestCase):
         mock_notify.assert_called_once_with(
             [sector],
             SectorSerializer,
-            message="created sector based on information from UISP. The following items may require attention:\n"
+            message="*created sector based on information from UISP*. The following items may require attention:\n"
             " - Mock change 1\n"
             " - Mock change 2",
         )
@@ -316,7 +315,7 @@ class TestUISPImportUtils(TestCase):
         mock_notify.assert_called_once_with(
             [sector],
             SectorSerializer,
-            message="created sector based on information from UISP. The following items may require attention:\n"
+            message="*created sector based on information from UISP*. The following items may require attention:\n"
             " - Mock change 1\n"
             " - Mock change 2",
         )
@@ -348,7 +347,7 @@ class TestUISPImportUtils(TestCase):
         mock_notify.assert_called_once_with(
             [ap],
             AccessPointSerializer,
-            message="created access point based on information from UISP. The following items may require attention:\n"
+            message="*created access point based on information from UISP*. The following items may require attention:\n"
             " - Mock change 1\n"
             " - Mock change 2",
         )

--- a/src/meshapi/util/admin_notifications.py
+++ b/src/meshapi/util/admin_notifications.py
@@ -34,8 +34,11 @@ def notify_administrators_of_data_issue(
         )
         return
 
+    if "\n" not in message:
+        message = f"*{message}*"
+
     slack_message = {
-        "text": f"Encountered the following data issue which may require admin attention: *{message}*. "
+        "text": f"Encountered the following data issue which may require admin attention: {message}. "
         f"When processing the following {model_instances[0]._meta.verbose_name_plural}: "
         + ", ".join(f"<{get_admin_url(m, site_base_url)}|{m}>" for m in model_instances)
         + ". Please open the database admin UI using the provided links to correct this.\n\n"

--- a/src/meshapi/util/uisp_import/utils.py
+++ b/src/meshapi/util/uisp_import/utils.py
@@ -99,15 +99,13 @@ def notify_admins_of_changes(
 
     if created:
         message = (
-            f"created {db_object._meta.verbose_name} based on information from UISP. "
+            f"*created {db_object._meta.verbose_name} based on information from UISP*. "
             f"The following items may require attention:\n" + "\n".join(" - " + change for change in change_list)
         )
     else:
         message = (
-            f"modified {db_object._meta.verbose_name} based on information from UISP. "
-            f"The following changes were made:\n"
-            + "\n".join(" - " + change for change in change_list)
-            + "\n(to prevent this, make changes to these fields in UISP rather than directly in MeshDB)"
+            f"*modified {db_object._meta.verbose_name} based on information from UISP*. "
+            f"The following changes were made:\n" + "\n".join(" - " + change for change in change_list) + "\n"
         )
 
     notify_administrators_of_data_issue(


### PR DESCRIPTION
Fixes an issue where the slack messages have really bad formatting due to the fact that newlines aren't allowed inside of bolded text.

Also removes some explanatory text that is confusing in most contexts, and should be obvious in the contexts where it is needed