### PR TITLE
Move unit tests from minio -> moto

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,8 +15,8 @@ SMTP_PORT=
 SMTP_USER=
 SMTP_PASSWORD=
 
-# For local testing
-S3_ENDPOINT="http://127.0.0.1:9000"
+# For local testing with Minio. Don't include unless you have minio configured
+# S3_ENDPOINT="http://127.0.0.1:9000"
 
 # Backups
 AWS_ACCESS_KEY_ID=

--- a/.github/workflows/run_django_tests.yaml
+++ b/.github/workflows/run_django_tests.yaml
@@ -39,20 +39,6 @@ jobs:
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: '3.11'
-      - name: Setup Minio
-        run: |
-            docker run -d -p 9000:9000 --name minio \
-            -e "MINIO_ACCESS_KEY=sampleaccesskey" \
-            -e "MINIO_SECRET_KEY=samplesecretkey" \
-            -e "MINIO_DEFAULT_BUCKETS=meshdb-join-form-log" \
-            -v /tmp/data:/data \
-            -v /tmp/config:/root/.minio \
-            minio/minio server /data
-
-            export AWS_ACCESS_KEY_ID=sampleaccesskey
-            export AWS_SECRET_ACCESS_KEY=samplesecretkey
-            export AWS_EC2_METADATA_DISABLED=true
-            aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://meshdb-join-form-log
       - name: "Upgrade pip"
         run: "pip install --upgrade pip"
       - name: "Install package"
@@ -73,8 +59,7 @@ jobs:
           DB_PASSWORD_RO: readonly
           JOIN_RECORD_BUCKET_NAME: meshdb-join-form-log
           JOIN_RECORD_PREFIX: dev-join-form-submissions
-          S3_ENDPOINT: http://127.0.0.1:9000
-          AWS_ACCESS_KEY_ID: sampleaccesskey 
+          AWS_ACCESS_KEY_ID: sampleaccesskey
           AWS_SECRET_ACCESS_KEY: samplesecretkey
           AWS_REGION: us-east-1
         run: coverage run src/manage.py test meshapi meshapi_hooks

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ If you would like to develop in a [Dev Container](https://code.visualstudio.com/
 4. In a different shell, outside of VS Code, start the other containers: `docker compose up -d postgres pelias redis` (as below).
 5. Continue on the VS Code terminal (where your project is opened) follow normal developer setup.
 
+##### Advanced - MinIO for Local Dev
+If you are going to use [minio](https://min.io/) for local S3 bucket emulation (not required for most tasks), also
+start the minio related containers with `docker compose up -d minio createbuckets`. To have your local DB instance 
+use Minio, you will also need to set `S3_ENDPOINT="http://127.0.0.1:9000"` in your `.env` file.
+
+> [!NOTE]
+> You only need `createbuckets` once. It will initialize the bucket that MinIO talks to
+
 #### Host
 
 If you are not using a Dev Container, for safety, create a venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ dev = [
     "djangorestframework-stubs[compatible-mypy]==3.15.*",
     "django-filter-stubs==0.1.3",
     "requests-mock==1.12.*",
-    "beautifulsoup4==4.12.*"
+    "beautifulsoup4==4.12.*",
+    "moto[s3]==5.0.*",
 ]
 
 [project.scripts]

--- a/src/meshapi/tests/test_replay_join_records.py
+++ b/src/meshapi/tests/test_replay_join_records.py
@@ -4,10 +4,16 @@ from unittest.mock import patch
 
 from django.core import management
 from django.test import TestCase
+from moto import mock_aws
 
 from meshapi.models.install import Install
 from meshapi.tests.sample_join_records import MOCK_JOIN_RECORD_PREFIX, basic_sample_join_records
-from meshapi.util.join_records import JoinRecord, JoinRecordProcessor, s3_content_to_join_record
+from meshapi.util.join_records import (
+    JOIN_RECORD_BUCKET_NAME,
+    JoinRecord,
+    JoinRecordProcessor,
+    s3_content_to_join_record,
+)
 
 
 # Integration test to ensure that we can fetch JoinRecords from an S3 bucket,
@@ -15,10 +21,12 @@ from meshapi.util.join_records import JoinRecord, JoinRecordProcessor, s3_conten
 # We should test a happy case, a case when the JoinRecord is bad (like a JoinRecord
 # somehow from Russia), and maybe mock a MeshDB 500 that just ends in us putting
 # the data back.
+@mock_aws
 class TestReplayJoinRecords(TestCase):
     p = JoinRecordProcessor()
 
     def setUp(self) -> None:
+        self.p.s3_client.create_bucket(Bucket=JOIN_RECORD_BUCKET_NAME)
         self.p.flush_test_data()
 
     def tearDown(self) -> None:

--- a/src/meshapi/util/join_records.py
+++ b/src/meshapi/util/join_records.py
@@ -11,7 +11,9 @@ from botocore.client import ClientError, Config
 
 from meshapi.views.forms import JoinFormRequest
 
+# Only used for dev with Minio. Don't set in deployed or unit testing envs
 JOIN_RECORD_ENDPOINT = os.environ.get("S3_ENDPOINT", None)
+
 JOIN_RECORD_BUCKET_NAME = os.environ.get("JOIN_RECORD_BUCKET_NAME")
 JOIN_RECORD_PREFIX = os.environ.get("JOIN_RECORD_PREFIX", "sample-basename")
 


### PR DESCRIPTION
Convert unit testing from minio to moto for mocked S3 calls

Also includes some of the docs changes from #710 