### PR TITLE
bump tracer version

### DIFF
--- a/infra/helm/meshdb/charts/celery/templates/deployment.yaml
+++ b/infra/helm/meshdb/charts/celery/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        admission.datadoghq.com/python-lib.version: v2.12
+        admission.datadoghq.com/python-lib.version: v2.17
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Bumps python tracing lib from 2.12 to 2.17

We should consider setting `apm.instrumentation.enabled=true` instead