### PR TITLE
Fix env configuration

### DIFF
--- a/infra/helm/meshdb/charts/celery/templates/deployment.yaml
+++ b/infra/helm/meshdb/charts/celery/templates/deployment.yaml
@@ -44,9 +44,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: meshdbconfig
-          envFrom:
-          - secretRef:
-              name: meshdb-secrets
+            - secretRef:
+                name: meshdb-secrets
           {{- if .livenessProbe }}
           livenessProbe:
             {{- toYaml .livenessProbe | nindent 12 }}

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -40,9 +40,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: meshdbconfig
-          envFrom:
-          - secretRef:
-              name: meshdb-secrets
+            - secretRef:
+                name: meshdb-secrets
           volumeMounts:
             - name: static-content-vol
               mountPath: /opt/meshdb/static


### PR DESCRIPTION
Fixes a problem where we had two `envFrom` blocks in the same chart, which seems to be causing a deployment to fail.

Originally, I was going to also figure out why helm isn't catching this, but it seems like that might be a little more involved. Going to do this to unblock people and  figure that out in a separate PR.