### PR TITLE
Add django-admin-site-search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "prettytable==3.11.*",
     "matplotlib==3.9.*",
     "django-ipware==7.0.1",
+    "django-admin-site-search==1.1.*",
 ]
 
 [project.optional-dependencies]

--- a/src/meshdb/admin.py
+++ b/src/meshdb/admin.py
@@ -1,11 +1,13 @@
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 
+from admin_site_search.views import AdminSiteSearchView
 from django.contrib import admin
 from django.http import HttpRequest
-from admin_site_search.views import AdminSiteSearchView
 
 
 class MeshDBAdminSite(AdminSiteSearchView, admin.AdminSite):
+    site_search_method: Literal["model_char_fields", "admin_search_fields"] = "admin_search_fields"
+
     def get_app_list(self, request: HttpRequest, app_label: Optional[str] = None) -> List[Any]:
         """Reorder the apps in the admin site.
 

--- a/src/meshdb/admin.py
+++ b/src/meshdb/admin.py
@@ -2,9 +2,10 @@ from typing import Any, List, Optional
 
 from django.contrib import admin
 from django.http import HttpRequest
+from admin_site_search.views import AdminSiteSearchView
 
 
-class MeshDBAdminSite(admin.AdminSite):
+class MeshDBAdminSite(AdminSiteSearchView, admin.AdminSite):
     def get_app_list(self, request: HttpRequest, app_label: Optional[str] = None) -> List[Any]:
         """Reorder the apps in the admin site.
 

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -206,6 +206,7 @@ INSTALLED_APPS = [
     "flags",
     "explorer",
     "simple_history",
+    "admin_site_search",
 ]
 
 MIDDLEWARE = [

--- a/src/meshdb/templates/admin/base_site.html
+++ b/src/meshdb/templates/admin/base_site.html
@@ -4,6 +4,8 @@
 
 {% block extrahead %}
     <link rel="shortcut icon" href="{% static 'meshweb/favicon.png' %}" />
+    {% include 'admin_site_search/head.html' %}
+    {{ block.super }}
 {% endblock %}
 
 {% block branding %}
@@ -18,4 +20,14 @@
     <a href="#" class="hidden" style="margin-left: 5px; vertical-align: middle; border: none;" id="show_map_button">
         <img src="{% static '/admin/map/img/map.png' %}" height="16px" title="Show Map">
     </a>
+{% endblock %}
+
+{% block footer %}
+    {{ block.super }}
+    {% include 'admin_site_search/modal.html' %}
+{% endblock %}
+
+{% block usertools %}
+    {% include 'admin_site_search/button.html' %}
+    {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
This PR implements [Django Admin Site Search](https://github.com/ahmedaljawahiry/django-admin-site-search) to MeshDB, so that you can easily search MeshDB. It adds a bar to the top of the interface you can click to open, or press `CTRL+K` (`CMD+K` on Mac) to open it.

![image](https://github.com/user-attachments/assets/6a5a4b59-b47e-42c2-b02b-e6061d109c86)

The normal search bars are still present (for now) if you wish to use those.

Closes #706 