### PR TITLE
Add tracing to Map endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY ./src/meshweb/static .
 
 COPY ./src .
 
-ENTRYPOINT ./scripts/entrypoint.sh && exec gunicorn 'meshdb.wsgi' --graceful-timeout 2 --bind=0.0.0.0:8081
+ENTRYPOINT ./scripts/entrypoint.sh && exec ddtrace-run gunicorn 'meshdb.wsgi' --graceful-timeout 2 --bind=0.0.0.0:8081

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "prettytable==3.11.*",
     "matplotlib==3.9.*",
     "django-ipware==7.0.1",
+    "ddtrace==2.17.*",
 ]
 
 [project.optional-dependencies]

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 from json import JSONDecodeError
 from typing import Any, Dict, List
 
+from ddtrace import tracer
+
 import requests
 from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q, Subquery
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view, inline_serializer
@@ -49,6 +51,7 @@ class MapDataNodeList(generics.ListAPIView):
     serializer_class = MapDataInstallSerializer
     pagination_class = None
 
+    @tracer.wrap()
     def get_queryset(self) -> List[Install]:  # type: ignore[override]
         all_installs = []
 
@@ -131,6 +134,7 @@ class MapDataNodeList(generics.ListAPIView):
         all_installs.sort(key=lambda i: i.install_number)
         return all_installs
 
+    @tracer.wrap()
     def list(self, request: Request, *args: List[Any], **kwargs: Dict[str, Any]) -> Response:
         response = super().list(request, args, kwargs)
 
@@ -219,6 +223,7 @@ class MapDataLinkList(generics.ListAPIView):
         # .exclude(to_device__status=Device.DeviceStatus.INACTIVE)
     )
 
+    @tracer.wrap()
     def list(self, request: Request, *args: List[Any], **kwargs: Dict[str, Any]) -> Response:
         response = super().list(request, *args, **kwargs)
 
@@ -431,6 +436,7 @@ class MapDataSectorList(generics.ListAPIView):
 class KioskListWrapper(APIView):
     permission_classes = [permissions.AllowAny]
 
+    @tracer.wrap()
     def get(self, request: Request) -> Response:
         try:
             response = requests.get(LINKNYC_KIOSK_DATA_URL)


### PR DESCRIPTION
I'd like to add some Datadog tracing to the map endpoints so we can understand if Andrew's theory of very heavy Python objects is correct. This will give us better viz in APM.

I will probably also enable profiling: https://docs.datadoghq.com/profiler/enabling/python/

