### PR TITLE
Add webhook for UISP device deactivation

### DIFF
--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -404,6 +404,7 @@ HOOK_EVENTS = {
     "link.updated": "meshapi.Link.updated+",
     "los.updated": "meshapi.LOS.updated+",
     "device.updated": "meshapi.Device.updated+",
+    "device.uisp-deactivated": "meshapi.Device.uisp-deactivated+",
     "sector.updated": "meshapi.Sector.updated+",
     "access_point.updated": "meshapi.AccessPoint.updated+",
     "building.deleted": "meshapi.Building.deleted+",


### PR DESCRIPTION
Adds a webhook that fires when the UISP import celery worker detects a device which has been offline in UISP for too long

This is to support a tool that @danielhmetro is working on which will notify users via email to confirm when we think their equipment is abandoned