### PR TITLE
Grant installers link add permissions

### DIFF
--- a/src/meshapi/management/commands/create_groups.py
+++ b/src/meshapi/management/commands/create_groups.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
             if (act == "change" and obj in models) or (act == "view" and obj in models) or code == "assign_nn":
                 installer.permissions.add(p)
 
-            if act == "add" and obj == "accesspoint":
+            if act == "add" and obj in ["accesspoint", "link"]:
                 installer.permissions.add(p)
 
             # admin


### PR DESCRIPTION
Installers don't have a workflow for adding links between omnis since these don't come in via UISP. Long term we should try to automate this and remove this permission (to try to prevent duplicate links from being added)