### PR TITLE
Exclude self-loops from map link JSON

### DIFF
--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -1123,12 +1123,6 @@ class TestViewsGetUnauthenticated(TestCase):
                     "status": "planned",
                 },
                 {
-                    "from": 1934,
-                    "installDate": 1706245200000,
-                    "status": "60GHz",
-                    "to": 1934,
-                },
-                {
                     "from": 56789,
                     "to": 123,
                     "status": "active",

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -195,6 +195,7 @@ class MapDataLinkList(generics.ListAPIView):
         Link.objects.exclude(status__in=[Link.LinkStatus.INACTIVE])
         .exclude(to_device__node__status=Node.NodeStatus.INACTIVE)
         .exclude(from_device__node__status=Node.NodeStatus.INACTIVE)
+        .exclude(from_device__node__network_number=F("to_device__node__network_number"))
         .prefetch_related("to_device__node")
         .prefetch_related("from_device__node")
         .filter(


### PR DESCRIPTION
Fixes a bug where node self loops appear in the map JSON when two devices on the same node have a link between them