### PR TITLE
Readiness + Startup probes

### DIFF
--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -3,7 +3,7 @@ name: Publish and Deploy
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, james/readinessProbe ]
   workflow_dispatch:
     branches:
       - main
@@ -51,7 +51,7 @@ jobs:
       environment: dev3
     secrets: inherit
     needs: push_to_registry
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
 
   integration_test_dev3:
     name: Integration test dev 3

--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -3,7 +3,7 @@ name: Publish and Deploy
 
 on:
   push:
-    branches: [ main, james/readinessProbe ]
+    branches: [ main ]
   workflow_dispatch:
     branches:
       - main
@@ -50,8 +50,8 @@ jobs:
     with:
       environment: dev3
     secrets: inherit
-    #needs: push_to_registry
-    #if: github.ref == 'refs/heads/main'
+    needs: push_to_registry
+    if: github.ref == 'refs/heads/main'
 
   integration_test_dev3:
     name: Integration test dev 3

--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -50,7 +50,7 @@ jobs:
     with:
       environment: dev3
     secrets: inherit
-    needs: push_to_registry
+    #needs: push_to_registry
     #if: github.ref == 'refs/heads/main'
 
   integration_test_dev3:

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -47,18 +47,30 @@ spec:
               mountPath: /opt/meshdb/static
           {{ if eq .Values.meshweb.liveness_probe "true" }}
           livenessProbe:
-           exec:
-             command:
-               - curl
-               - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
-           periodSeconds: 3
-           initialDelaySeconds: 4
-           timeoutSeconds: 3
-           {{ end }}
-          livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            httpGet:
+              path: /api/v1
+              port: {{ .Values.meshweb.port }}
+              scheme: http
+              httpHeaders:
+                - name: host
+                  value: 127.0.0.1
+            periodSeconds: 3
+            initialDelaySeconds: 4
+            timeoutSeconds: 3
+          {{ end }}
+          {{ if eq .Values.meshweb.readiness_probe "true" }} 
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            httpGet:
+              path: /api/v1
+              port: {{ .Values.meshweb.port }}
+              scheme: http
+              httpHeaders:
+                - name: host
+                  value: 127.0.0.1
+            periodSeconds: 3
+            initialDelaySeconds: 4
+            timeoutSeconds: 3
+          {{ end }}
           resources:
             {{- toYaml .Values.meshweb.resources | nindent 12 }}
       volumes:

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -49,20 +49,20 @@ spec:
           livenessProbe:
             exec:
               command:
-                - curl
-                - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
-                - -s
+                - bash
+                - -c
+                - 'curl http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1/ -H "Host: db.nycmesh.net" -s | grep meshin'
             periodSeconds: 3
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             timeoutSeconds: 3
           {{ end }}
           {{ if eq .Values.meshweb.readiness_probe "true" }} 
           readinessProbe:
             exec:
               command:
-                - curl
-                - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
-                - -s
+                - bash
+                - -c
+                - 'curl http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1/ -H "Host: db.nycmesh.net" -s | grep meshin'
             periodSeconds: 3
             initialDelaySeconds: 20
             timeoutSeconds: 3

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -51,7 +51,8 @@ spec:
               command:
                 - curl
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
-                - --connect-timeout 2
+                - --connect-timeout
+                - 2
                 - -s
             periodSeconds: 3
             initialDelaySeconds: 4
@@ -63,7 +64,8 @@ spec:
               command:
                 - curl
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
-                - --connect-timeout 2
+                - --connect-timeout
+                - 2
                 - -s
             periodSeconds: 3
             initialDelaySeconds: 20

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -47,20 +47,20 @@ spec:
               mountPath: /opt/meshdb/static
           {{ if eq .Values.meshweb.liveness_probe "true" }}
           livenessProbe:
-            httpGet:
-              path: /api/v1
-              port: {{ .Values.meshweb.port }}
-              scheme: HTTP
+            exec:
+              command:
+                - curl
+                - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
             periodSeconds: 3
             initialDelaySeconds: 4
             timeoutSeconds: 3
           {{ end }}
           {{ if eq .Values.meshweb.readiness_probe "true" }} 
           readinessProbe:
-            httpGet:
-              path: /api/v1
-              port: {{ .Values.meshweb.port }}
-              scheme: HTTP
+            exec:
+              command:
+                - curl
+                - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
             periodSeconds: 3
             initialDelaySeconds: 20
             timeoutSeconds: 3

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -52,7 +52,7 @@ spec:
                 - bash
                 - -c
                 - 'curl http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1/ -H "Host: db.nycmesh.net" -s | grep meshin'
-            periodSeconds: 3
+            periodSeconds: 10
             initialDelaySeconds: 30
             timeoutSeconds: 3
           {{ end }}
@@ -64,7 +64,7 @@ spec:
                 - -c
                 - 'curl http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1/ -H "Host: db.nycmesh.net" -s | grep meshin'
             periodSeconds: 3
-            initialDelaySeconds: 20
+            initialDelaySeconds: 10
             timeoutSeconds: 3
           {{ end }}
           {{ if eq .Values.meshweb.startup_probe "true" }} 

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -51,6 +51,8 @@ spec:
               command:
                 - curl
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
+                - --connect-timeout 2
+                - -s
             periodSeconds: 3
             initialDelaySeconds: 4
             timeoutSeconds: 3
@@ -61,6 +63,8 @@ spec:
               command:
                 - curl
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
+                - --connect-timeout 2
+                - -s
             periodSeconds: 3
             initialDelaySeconds: 20
             timeoutSeconds: 3

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -52,7 +52,7 @@ spec:
                 - curl
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
                 - --connect-timeout
-                - 2
+                - "2"
                 - -s
             periodSeconds: 3
             initialDelaySeconds: 4
@@ -65,7 +65,7 @@ spec:
                 - curl
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
                 - --connect-timeout
-                - 2
+                - "2"
                 - -s
             periodSeconds: 3
             initialDelaySeconds: 20

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -50,7 +50,7 @@ spec:
             httpGet:
               path: /api/v1
               port: {{ .Values.meshweb.port }}
-              scheme: http
+              scheme: HTTP
               httpHeaders:
                 - name: host
                   value: 127.0.0.1
@@ -63,7 +63,7 @@ spec:
             httpGet:
               path: /api/v1
               port: {{ .Values.meshweb.port }}
-              scheme: http
+              scheme: HTTP
               httpHeaders:
                 - name: host
                   value: 127.0.0.1

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -67,6 +67,17 @@ spec:
             initialDelaySeconds: 20
             timeoutSeconds: 3
           {{ end }}
+          {{ if eq .Values.meshweb.startup_probe "true" }} 
+          startupProbe:
+            exec:
+              command:
+                - bash
+                - -c
+                - 'curl http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1/ -H "Host: db.nycmesh.net" -s | grep meshin'
+            periodSeconds: 3
+            initialDelaySeconds: 20
+            timeoutSeconds: 3
+          {{ end }}
           resources:
             {{- toYaml .Values.meshweb.resources | nindent 12 }}
       volumes:

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -77,6 +77,7 @@ spec:
             periodSeconds: 3
             initialDelaySeconds: 20
             timeoutSeconds: 3
+            failureThreshold: 20
           {{ end }}
           resources:
             {{- toYaml .Values.meshweb.resources | nindent 12 }}

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -51,8 +51,6 @@ spec:
               command:
                 - curl
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
-                - --connect-timeout
-                - "2"
                 - -s
             periodSeconds: 3
             initialDelaySeconds: 4
@@ -64,8 +62,6 @@ spec:
               command:
                 - curl
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
-                - --connect-timeout
-                - "2"
                 - -s
             periodSeconds: 3
             initialDelaySeconds: 20

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -51,9 +51,6 @@ spec:
               path: /api/v1
               port: {{ .Values.meshweb.port }}
               scheme: HTTP
-              httpHeaders:
-                - name: host
-                  value: 127.0.0.1
             periodSeconds: 3
             initialDelaySeconds: 4
             timeoutSeconds: 3
@@ -64,11 +61,8 @@ spec:
               path: /api/v1
               port: {{ .Values.meshweb.port }}
               scheme: HTTP
-              httpHeaders:
-                - name: host
-                  value: 127.0.0.1
             periodSeconds: 3
-            initialDelaySeconds: 4
+            initialDelaySeconds: 20
             timeoutSeconds: 3
           {{ end }}
           resources:

--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -53,7 +53,7 @@ spec:
                 - http://127.0.0.1:{{ .Values.meshweb.port }}/api/v1
                 - -s
             periodSeconds: 3
-            initialDelaySeconds: 4
+            initialDelaySeconds: 15
             timeoutSeconds: 3
           {{ end }}
           {{ if eq .Values.meshweb.readiness_probe "true" }} 

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -38,7 +38,7 @@ meshweb:
   static_pvc_name: "meshdb-static-pvc"
   static_pvc_size: "1Gi"
   liveness_probe: "true"
-  readiness_probe: "false"
+  readiness_probe: "true"
   image:
     repository: willnilges/meshdb
     tag: main

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -38,7 +38,8 @@ meshweb:
   static_pvc_name: "meshdb-static-pvc"
   static_pvc_size: "1Gi"
   liveness_probe: "true"
-  readiness_probe: "true"
+  readiness_probe: "false"
+  startup_probe: "true"
   image:
     repository: willnilges/meshdb
     tag: main

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -10,6 +10,7 @@ pg:
   pvc_name: "meshdb-postgres-encyrpted-pvc"
   pvc_size: "20Gi"
   liveness_probe: "true"
+  readiness_probe: "true"
   podSecurityContext: {}
   # fsGroup: 2000
   securityContext: {}

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -37,7 +37,7 @@ meshweb:
   disable_pano_edits: "True"
   static_pvc_name: "meshdb-static-pvc"
   static_pvc_size: "1Gi"
-  liveness_probe: "true"
+  liveness_probe: "false"
   readiness_probe: "false"
   image:
     repository: willnilges/meshdb

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -38,7 +38,7 @@ meshweb:
   static_pvc_name: "meshdb-static-pvc"
   static_pvc_size: "1Gi"
   liveness_probe: "true"
-  readiness_probe: "false"
+  readiness_probe: "true"
   startup_probe: "true"
   image:
     repository: willnilges/meshdb

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -37,7 +37,7 @@ meshweb:
   disable_pano_edits: "True"
   static_pvc_name: "meshdb-static-pvc"
   static_pvc_size: "1Gi"
-  liveness_probe: "false"
+  liveness_probe: "true"
   readiness_probe: "false"
   image:
     repository: willnilges/meshdb

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -10,7 +10,6 @@ pg:
   pvc_name: "meshdb-postgres-encyrpted-pvc"
   pvc_size: "20Gi"
   liveness_probe: "true"
-  readiness_probe: "true"
   podSecurityContext: {}
   # fsGroup: 2000
   securityContext: {}
@@ -39,6 +38,7 @@ meshweb:
   static_pvc_name: "meshdb-static-pvc"
   static_pvc_size: "1Gi"
   liveness_probe: "true"
+  readiness_probe: "true"
   image:
     repository: willnilges/meshdb
     tag: main

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -38,7 +38,7 @@ meshweb:
   static_pvc_name: "meshdb-static-pvc"
   static_pvc_size: "1Gi"
   liveness_probe: "true"
-  readiness_probe: "true"
+  readiness_probe: "false"
   image:
     repository: willnilges/meshdb
     tag: main


### PR DESCRIPTION
The liveness probe was not working because the element was duplicated with the second being empty. Re-enable it, make it work, and add readiness + startup probes to allow for slow startups, while pulling pods from the service and eventually restarting them if they are unresponsive.

Let's let this soak in dev for a while.