### PR TITLE
Improve node assignment coverage across building groups

### DIFF
--- a/src/meshapi/models/install.py
+++ b/src/meshapi/models/install.py
@@ -142,4 +142,11 @@ class Install(models.Model):
             if self.install_number != original.install_number:
                 raise ValidationError("Install number is immutable")
 
+        if self._state.adding:
+            if not self.node:
+                if self.building.primary_node:
+                    self.node = self.building.primary_node
+                elif self.building.nodes:
+                    self.node = self.building.nodes.first()
+
         super().save(*args, **kwargs)

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -580,6 +580,12 @@ def network_number_assignment(request: Request) -> Response:
         nn_install.status = Install.InstallStatus.PENDING
         dirty = True
 
+    other_building_installs = [install for install in nn_building.installs.all() if install != nn_install]
+    for install in other_building_installs:
+        if install.node is None:
+            dirty = True
+            install.node = nn_install.node
+
     # If nothing was changed by this request, return a 200 instead of a 201
     if not dirty:
         message = f"This Install Number ({r.install_number}) already has a "
@@ -601,6 +607,8 @@ def network_number_assignment(request: Request) -> Response:
         nn_install.node.save()
         nn_building.save()
         nn_install.save()
+        for install in other_building_installs:
+            install.save()
     except IntegrityError:
         logging.exception("NN Request failed. Could not save node number.")
         return Response(


### PR DESCRIPTION
Fills some gaps in the consistency of the NN <-> Install <-> Building triad, by ensuring that when we assign an NN to an install within a building, all installs within that building that don't already have an NN receive the newly created one

Also covers the case where an install object is created in a building that already has an NN

For backfill I wrote [this](https://db.nycmesh.net/explorer/23/) SQL Explorer query we can use to clean up the past occurrences of this issue