### PR TITLE
Use MeshDB credentials in the Query Form

### DIFF
--- a/src/meshapi/permissions.py
+++ b/src/meshapi/permissions.py
@@ -49,6 +49,16 @@ class HasMaintenanceModePermission(HasDjangoPermission):
 class HasExplorerAccessPermission(HasDjangoPermission):
     django_permission = "meshapi.explorer_access"
 
+# Janky
+class LegacyNNAssignmentPassword(permissions.BasePermission):
+    def has_permission(self, request: Request, view: Any) -> bool:
+        request_json = json.loads(request.body)
+        if "password" in request_json and request_json["password"] == os.environ.get("NN_ASSIGN_PSK"):
+            return True
+
+        raise PermissionDenied("Authentication Failed.")
+
+
 def check_has_model_view_permission(user: Optional[User], model: Model) -> bool:
     if not user:
         # Unauthenticated requests do not have permission by default

--- a/src/meshapi/permissions.py
+++ b/src/meshapi/permissions.py
@@ -49,28 +49,6 @@ class HasMaintenanceModePermission(HasDjangoPermission):
 class HasExplorerAccessPermission(HasDjangoPermission):
     django_permission = "meshapi.explorer_access"
 
-
-# Janky
-class LegacyMeshQueryPassword(permissions.BasePermission):
-    def has_permission(self, request: Request, view: View) -> bool:
-        if (
-            request.headers["Authorization"]
-            and request.headers["Authorization"] == f"Bearer {os.environ.get('QUERY_PSK')}"
-        ):
-            return True
-
-        raise PermissionDenied("Authentication Failed.")
-
-
-class LegacyNNAssignmentPassword(permissions.BasePermission):
-    def has_permission(self, request: Request, view: Any) -> bool:
-        request_json = json.loads(request.body)
-        if "password" in request_json and request_json["password"] == os.environ.get("NN_ASSIGN_PSK"):
-            return True
-
-        raise PermissionDenied("Authentication Failed.")
-
-
 def check_has_model_view_permission(user: Optional[User], model: Model) -> bool:
     if not user:
         # Unauthenticated requests do not have permission by default

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -19,7 +19,7 @@ from validate_email.exceptions import EmailValidationError
 
 from meshapi.exceptions import AddressError
 from meshapi.models import AddressTruthSource, Building, Install, Member, Node
-from meshapi.permissions import HasNNAssignPermission, LegacyNNAssignmentPassword
+from meshapi.permissions import HasNNAssignPermission 
 from meshapi.serializers import MemberSerializer
 from meshapi.util.admin_notifications import notify_administrators_of_data_issue
 from meshapi.util.constants import RECAPTCHA_CHECKBOX_TOKEN_HEADER, RECAPTCHA_INVISIBLE_TOKEN_HEADER
@@ -481,7 +481,7 @@ nn_form_success_schema = inline_serializer(
     ),
 )
 @api_view(["POST"])
-@permission_classes([HasNNAssignPermission | LegacyNNAssignmentPassword])
+@permission_classes([HasNNAssignPermission])
 @transaction.atomic
 @advisory_lock("nn_assignment_lock")
 def network_number_assignment(request: Request) -> Response:
@@ -492,8 +492,6 @@ def network_number_assignment(request: Request) -> Response:
 
     try:
         request_json = json.loads(request.body)
-        if "password" in request_json:
-            del request_json["password"]
 
         r = NetworkNumberAssignmentRequest(**request_json)
     except (TypeError, JSONDecodeError):

--- a/src/meshapi/views/query_api.py
+++ b/src/meshapi/views/query_api.py
@@ -6,7 +6,6 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from meshapi.docs import query_form_password_param
 from meshapi.models import Install, Member
-from meshapi.permissions import LegacyMeshQueryPassword
 from meshapi.serializers.query_api import QueryFormSerializer
 from meshapi.views.lookups import FilterRequiredListAPIView
 
@@ -61,7 +60,6 @@ class QueryMember(FilterRequiredListAPIView):
     )
     serializer_class = QueryFormSerializer
     filterset_class = QueryMemberFilter
-    permission_classes = [LegacyMeshQueryPassword]
 
 
 class QueryInstallFilter(filters.FilterSet):
@@ -91,7 +89,6 @@ class QueryInstall(FilterRequiredListAPIView):
     )
     serializer_class = QueryFormSerializer
     filterset_class = QueryInstallFilter
-    permission_classes = [LegacyMeshQueryPassword]
 
 
 class QueryBuildingFilter(filters.FilterSet):
@@ -125,4 +122,3 @@ class QueryBuilding(FilterRequiredListAPIView):
     )
     serializer_class = QueryFormSerializer
     filterset_class = QueryBuildingFilter
-    permission_classes = [LegacyMeshQueryPassword]

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -136,6 +136,9 @@ ALLOWED_HOSTS = [
     "devdb.nycmesh.net",
 ]
 
+# Enable this so that Meshforms can use login credentials
+CORS_ALLOW_CREDENTIALS = True
+
 CORS_ALLOWED_ORIGINS = [
     "https://forms.nycmesh.net",
     "https://forms.devdb.nycmesh.net",
@@ -173,6 +176,7 @@ if DEBUG:
     ]
 
     CSRF_TRUSTED_ORIGINS += [
+        "http://127.0.0.1:3000",
         "http://127.0.0.1:8080",
         "http://127.0.0.1",
     ]


### PR DESCRIPTION
- [x] This allows us to use MeshDB's credentials in the query form if the user is already logged in.
- [ ] If they are not logged in, they will be redirected to the login page.
- [ ] Might try to do the NN Assign Form, but CORS is a huge pain in the ass.

Sister: https://github.com/nycmeshnet/meshforms/pull/146/