### PR TITLE
Don't call save on devices, links, or LOSes unnecessarily

### DIFF
--- a/src/meshapi/tests/test_uisp_import.py
+++ b/src/meshapi/tests/test_uisp_import.py
@@ -433,9 +433,13 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
         self.assertEqual(self.link.type, Link.LinkType.FIVE_GHZ)
         self.assertEqual(self.link.abandon_date, last_seen_date.date())
 
+        # lol, uuid is non-deterministic.
         self.assertEqual(
             change_messages,
             [
+                'Changed UISP link ID to fake-uisp-uuid2 for NN1234 ↔ NN5678 link (ID '
+                f'{self.link.id}). This is likely due to a UISP UUID '
+                'rotation',
                 "Changed connected device pair from [nycmesh-1234-dev1, nycmesh-5678-dev2] to [nycmesh-1234-dev1, nycmesh-9012-dev3]",
                 "Marked as Inactive due to it being offline in UISP for more than 30 days",
             ],
@@ -748,6 +752,7 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
 
         self.assertEqual(change_messages, [])
 
+
 class TestUISPImportHandlersDontDuplicateHistory(TransactionTestCase):
     def setUp(self) -> None:
         self.node1 = Node(
@@ -801,9 +806,6 @@ class TestUISPImportHandlersDontDuplicateHistory(TransactionTestCase):
         )
         self.link1.save()
 
-
-
-
     @patch("meshapi.util.uisp_import.sync_handlers.notify_admins_of_changes")
     def test_import_and_sync_devices_and_ensure_history_does_not_duplicate(self, mock_notify_admins):
 
@@ -817,7 +819,7 @@ class TestUISPImportHandlersDontDuplicateHistory(TransactionTestCase):
                 },
                 "identification": {
                     "id": "uisp-uuid1",
-                    "name": "nycmesh-1234-dev69", # Gonna change dev1 to dev69
+                    "name": "nycmesh-1234-dev69",  # Gonna change dev1 to dev69
                     "category": "wireless",
                     "type": "airMax",
                 },
@@ -871,7 +873,7 @@ class TestUISPImportHandlersDontDuplicateHistory(TransactionTestCase):
         created_device.refresh_from_db()
         length_3 = len(created_device.history.all())
         self.assertEqual(2, length_3)
-        
+
 
 class TestUISPImportHandlers(TransactionTestCase):
     def setUp(self):

--- a/src/meshapi/tests/test_uisp_import.py
+++ b/src/meshapi/tests/test_uisp_import.py
@@ -352,117 +352,6 @@ class TestUISPImportUtils(TestCase):
             " - Mock change 2",
         )
 
-
-class TestUISPImportUpdateObjectsAndDontDuplicateHistory(TransactionTestCase):
-    def setUp(self):
-        self.node1 = Node(
-            network_number=1234,
-            status=Node.NodeStatus.ACTIVE,
-            type=Node.NodeType.STANDARD,
-            latitude=0,
-            longitude=0,
-        )
-        self.node1.save()
-
-        self.node2 = Node(
-            network_number=5678,
-            status=Node.NodeStatus.ACTIVE,
-            type=Node.NodeType.STANDARD,
-            latitude=0,
-            longitude=0,
-        )
-        self.node2.save()
-
-        self.node3 = Node(
-            network_number=9012,
-            status=Node.NodeStatus.ACTIVE,
-            type=Node.NodeType.STANDARD,
-            latitude=0,
-            longitude=0,
-        )
-        self.node3.save()
-
-        self.device1 = Device(
-            node=self.node1,
-            status=Device.DeviceStatus.ACTIVE,
-            name="nycmesh-1234-dev1",
-        )
-        self.device1.save()
-
-        self.device2 = Device(
-            node=self.node2,
-            status=Device.DeviceStatus.ACTIVE,
-            name="nycmesh-5678-dev2",
-        )
-        self.device2.save()
-
-        self.device3 = Device(
-            node=self.node3,
-            status=Device.DeviceStatus.ACTIVE,
-            name="nycmesh-9012-dev3",
-        )
-        self.device3.save()
-
-        self.link = Link(
-            from_device=self.device1,
-            to_device=self.device2,
-            status=Link.LinkStatus.ACTIVE,
-            type=Link.LinkType.FIVE_GHZ,
-            uisp_id="fake-uisp-uuid",
-        )
-        self.link.save()
-
-    @patch("meshapi.util.uisp_import.update_objects.get_uisp_link_last_seen")
-    def test_update_link_many_changes_and_dont_duplicate_history(self, mock_get_last_seen):
-        last_seen_date = datetime.datetime(2018, 11, 14, 15, 20, 32, 4000, tzinfo=tzutc())
-        mock_get_last_seen.return_value = last_seen_date
-
-        # Just one change from when we created it
-        self.assertEqual(1, len(self.link.history.all()))
-
-        change_messages = update_link_from_uisp_data(
-            self.link,
-            uisp_link_id="fake-uisp-uuid2",
-            uisp_from_device=self.device1,
-            uisp_to_device=self.device3,
-            uisp_status=Link.LinkStatus.INACTIVE,
-        )
-
-        self.link.refresh_from_db()
-        self.assertEqual(self.link.uisp_id, "fake-uisp-uuid2")
-        self.assertEqual(self.link.from_device, self.device1)
-        self.assertEqual(self.link.to_device, self.device3)
-        self.assertEqual(self.link.status, Link.LinkStatus.INACTIVE)
-        self.assertEqual(self.link.type, Link.LinkType.FIVE_GHZ)
-        self.assertEqual(self.link.abandon_date, last_seen_date.date())
-
-        # lol, uuid is non-deterministic.
-        self.assertEqual(
-            change_messages,
-            [
-                'Changed UISP link ID to fake-uisp-uuid2 for NN1234 ↔ NN5678 link (ID '
-                f'{self.link.id}). This is likely due to a UISP UUID '
-                'rotation',
-                "Changed connected device pair from [nycmesh-1234-dev1, nycmesh-5678-dev2] to [nycmesh-1234-dev1, nycmesh-9012-dev3]",
-                "Marked as Inactive due to it being offline in UISP for more than 30 days",
-            ],
-        )
-
-        # Legitimite update
-        self.assertEqual(2, len(self.link.history.all()))
-
-        change_messages = update_link_from_uisp_data(
-            self.link,
-            uisp_link_id="fake-uisp-uuid2",
-            uisp_from_device=self.device1,
-            uisp_to_device=self.device3,
-            uisp_status=Link.LinkStatus.INACTIVE,
-        )
-
-        # Don't make another history object
-        self.link.refresh_from_db()
-        self.assertEqual(2, len(self.link.history.all()))
-
 class TestUISPImportUpdateObjects(TransactionTestCase):
     def setUp(self):
         self.node1 = Node(
@@ -527,7 +416,7 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
         last_seen_date = datetime.datetime(2018, 11, 14, 15, 20, 32, 4000, tzinfo=tzutc())
         mock_get_last_seen.return_value = last_seen_date
 
-        # Just one change from when we created it
+        # Link should have just one history entry from when we created it
         self.assertEqual(1, len(self.link.history.all()))
 
         change_messages = update_link_from_uisp_data(
@@ -558,9 +447,10 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
             ],
         )
 
-        # Legitimite update
+        # Link should have a second entry, due to legitimate update
         self.assertEqual(2, len(self.link.history.all()))
 
+        # Run the update again...
         change_messages = update_link_from_uisp_data(
             self.link,
             uisp_link_id="fake-uisp-uuid2",
@@ -569,7 +459,7 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
             uisp_status=Link.LinkStatus.INACTIVE,
         )
 
-        # Don't make another history object
+        # And it SHOULD NOT make another history object
         self.link.refresh_from_db()
         self.assertEqual(2, len(self.link.history.all()))
 
@@ -1977,6 +1867,7 @@ class TestUISPImportHandlers(TransactionTestCase):
         )
         los2.save()
 
+        # LOS should have one history entry from creation
         self.assertEqual(1, len(los1.history.all()))
 
         sync_link_table_into_los_objects()
@@ -1993,12 +1884,18 @@ class TestUISPImportHandlers(TransactionTestCase):
         self.assertEqual(los2.source, LOS.LOSSource.EXISTING_LINK)
         self.assertEqual(los2.analysis_date, datetime.date.today())
 
+        # Get another entry from legitimite update
         self.assertEqual(2, len(los1.history.all()))
+        self.assertEqual(2, len(los2.history.all()))
 
+        # Run the sync again...
         sync_link_table_into_los_objects()
 
+        # SHOULD NOT have a third entry
         los1.refresh_from_db()
+        los2.refresh_from_db()
         self.assertEqual(2, len(los1.history.all()))
+        self.assertEqual(2, len(los2.history.all()))
 
     def test_sync_links_with_los_inactive_link(self):
         self.link1.status = Link.LinkStatus.INACTIVE

--- a/src/meshapi/tests/test_uisp_import.py
+++ b/src/meshapi/tests/test_uisp_import.py
@@ -436,13 +436,9 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
         self.assertEqual(self.link.type, Link.LinkType.FIVE_GHZ)
         self.assertEqual(self.link.abandon_date, last_seen_date.date())
 
-        # lol, uuid is non-deterministic.
         self.assertEqual(
             change_messages,
             [
-                "Changed UISP link ID to fake-uisp-uuid2 for NN1234 ↔ NN5678 link (ID "
-                f"{self.link.id}). This is likely due to a UISP UUID "
-                "rotation",
                 "Changed connected device pair from [nycmesh-1234-dev1, nycmesh-5678-dev2] to [nycmesh-1234-dev1, nycmesh-9012-dev3]",
                 "Marked as Inactive due to it being offline in UISP for more than 30 days",
             ],

--- a/src/meshapi/tests/test_uisp_import.py
+++ b/src/meshapi/tests/test_uisp_import.py
@@ -352,6 +352,7 @@ class TestUISPImportUtils(TestCase):
             " - Mock change 2",
         )
 
+
 class TestUISPImportUpdateObjects(TransactionTestCase):
     def setUp(self):
         self.node1 = Node(
@@ -439,9 +440,9 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
         self.assertEqual(
             change_messages,
             [
-                'Changed UISP link ID to fake-uisp-uuid2 for NN1234 ↔ NN5678 link (ID '
-                f'{self.link.id}). This is likely due to a UISP UUID '
-                'rotation',
+                "Changed UISP link ID to fake-uisp-uuid2 for NN1234 ↔ NN5678 link (ID "
+                f"{self.link.id}). This is likely due to a UISP UUID "
+                "rotation",
                 "Changed connected device pair from [nycmesh-1234-dev1, nycmesh-5678-dev2] to [nycmesh-1234-dev1, nycmesh-9012-dev3]",
                 "Marked as Inactive due to it being offline in UISP for more than 30 days",
             ],
@@ -462,7 +463,6 @@ class TestUISPImportUpdateObjects(TransactionTestCase):
         # And it SHOULD NOT make another history object
         self.link.refresh_from_db()
         self.assertEqual(2, len(self.link.history.all()))
-
 
     @patch("meshapi.util.uisp_import.update_objects.get_uisp_link_last_seen")
     def test_update_link_add_abandon_date(self, mock_get_last_seen):

--- a/src/meshapi/util/uisp_import/sync_handlers.py
+++ b/src/meshapi/util/uisp_import/sync_handlers.py
@@ -375,11 +375,16 @@ def sync_link_table_into_los_objects() -> None:
                         changed_los = True
 
                     # Keep the LOS analysis date accurate for all that come from existing links
-                    if existing_los.source == LOS.LOSSource.EXISTING_LINK and link.last_functioning_date_estimate:
+                    if (
+                        existing_los.source == LOS.LOSSource.EXISTING_LINK
+                        and link.last_functioning_date_estimate
+                        and existing_los.analysis_date != link.last_functioning_date_estimate
+                    ):
                         existing_los.analysis_date = link.last_functioning_date_estimate
                         changed_los = True
 
                     if changed_los:
+                        print("changed los")
                         existing_los.save()
                 continue
 

--- a/src/meshapi/util/uisp_import/sync_handlers.py
+++ b/src/meshapi/util/uisp_import/sync_handlers.py
@@ -83,6 +83,9 @@ def import_and_sync_uisp_devices(uisp_devices: List[UISPDevice]) -> None:
             parse_uisp_datetime(uisp_device["overview"]["lastSeen"]) if uisp_device["overview"]["lastSeen"] else None
         )
 
+        # This block guards against most duplication by checking uisp-uuid against
+        # the uisp-uuids we already know about.
+        # Further avoidance of saving historical records is done in the update function
         with transaction.atomic():
             existing_devices: List[Device] = list(Device.objects.filter(uisp_id=uisp_uuid).select_for_update())
             if existing_devices:
@@ -129,6 +132,8 @@ def import_and_sync_uisp_devices(uisp_devices: List[UISPDevice]) -> None:
                 uisp_device["identification"]["model"], DEFAULT_SECTOR_WIDTH
             )
 
+            # Only when we're sure the sector doesn't exist do we save it
+            # XXX (wdn): is this the only place we try to save sectors in here?
             sector = Sector(
                 **device_fields,
                 azimuth=guessed_compass_heading or DEFAULT_SECTOR_AZIMUTH,
@@ -241,6 +246,8 @@ def import_and_sync_uisp_links(uisp_links: List[UISPDataLink]) -> None:
                     message=f"Possible duplicate objects detected, links share the same UISP ID ({uisp_uuid})",
                 )
 
+            # XXX (wdn): Do we want to make a history record in this case? I _think_ so?
+            # maybe i dont understand this well enough
             if not existing_links:
                 # Under some circumstances, UISP randomly changes the internal ID it uses for
                 # ethernet link objects. We attempt to detect that here, by finding existing MeshDB
@@ -286,6 +293,8 @@ def import_and_sync_uisp_links(uisp_links: List[UISPDataLink]) -> None:
                         notify_admins_of_changes(existing_link, change_list)
                 continue
 
+        # By now, we're reasonably sure the link doesn't exist, so go ahead and
+        # create it.
         link = Link(
             from_device=uisp_from_device,
             to_device=uisp_to_device,
@@ -355,18 +364,27 @@ def sync_link_table_into_los_objects() -> None:
 
             if len(existing_los_objects):
                 for existing_los in existing_los_objects:
+                    # Keep track of whether or not we actually changed anything,
+                    # so that we don't unnecessarily save later.
+                    changed_los = False
+
                     # Supersede manually annotated LOSes with their auto-generated counterparts,
                     # once they come online as links
                     if link.status == Link.LinkStatus.ACTIVE and existing_los.source == LOS.LOSSource.HUMAN_ANNOTATED:
                         existing_los.source = LOS.LOSSource.EXISTING_LINK
+                        changed_los = True
 
                     # Keep the LOS analysis date accurate for all that come from existing links
                     if existing_los.source == LOS.LOSSource.EXISTING_LINK and link.last_functioning_date_estimate:
                         existing_los.analysis_date = link.last_functioning_date_estimate
+                        changed_los = True
 
-                    existing_los.save()
+                    if changed_los:
+                        existing_los.save()
                 continue
 
+        # At this point, we're reasonably sure the LOS does not exist, so go ahead
+        # and create a new one.
         los = LOS(
             from_building=from_building,
             to_building=to_building,

--- a/src/meshapi/util/uisp_import/sync_handlers.py
+++ b/src/meshapi/util/uisp_import/sync_handlers.py
@@ -245,8 +245,6 @@ def import_and_sync_uisp_links(uisp_links: List[UISPDataLink]) -> None:
                     message=f"Possible duplicate objects detected, links share the same UISP ID ({uisp_uuid})",
                 )
 
-            # XXX (wdn): Do we want to make a history record in this case? I _think_ so?
-            # maybe i dont understand this well enough
             if not existing_links:
                 # Under some circumstances, UISP randomly changes the internal ID it uses for
                 # ethernet link objects. We attempt to detect that here, by finding existing MeshDB

--- a/src/meshapi/util/uisp_import/sync_handlers.py
+++ b/src/meshapi/util/uisp_import/sync_handlers.py
@@ -133,7 +133,6 @@ def import_and_sync_uisp_devices(uisp_devices: List[UISPDevice]) -> None:
             )
 
             # Only when we're sure the sector doesn't exist do we save it
-            # XXX (wdn): is this the only place we try to save sectors in here?
             sector = Sector(
                 **device_fields,
                 azimuth=guessed_compass_heading or DEFAULT_SECTOR_AZIMUTH,

--- a/src/meshapi/util/uisp_import/update_objects.py
+++ b/src/meshapi/util/uisp_import/update_objects.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import List, Optional
 
 import requests
@@ -104,12 +105,17 @@ def update_link_from_uisp_data(
 ) -> List[str]:
     change_messages = []
 
+    # We can't add change messages because they're super spammy,
+    # so use this to determine if we should save when changing the uisp_id.
+    uisp_link_id_changed = False
+
     if uisp_link_id != existing_link.uisp_id:
         existing_link.uisp_id = uisp_link_id
-        change_messages.append(
+        logging.info(
             f"Changed UISP link ID to {uisp_link_id} for {existing_link} link (ID {existing_link.id}). "
             f"This is likely due to a UISP UUID rotation"
         )
+        uisp_link_id_changed = True
 
     uisp_device_pair = {uisp_to_device, uisp_from_device}
     db_device_pair = {existing_link.from_device, existing_link.to_device}
@@ -166,6 +172,6 @@ def update_link_from_uisp_data(
 
     # Only save the object if there actually are change_messages, otherwise don't
     # to avoid creating an unnecessary object.
-    if change_messages:
+    if change_messages or uisp_link_id_changed:
         existing_link.save()
     return change_messages

--- a/src/meshapi/util/uisp_import/update_objects.py
+++ b/src/meshapi/util/uisp_import/update_objects.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 from typing import List, Optional
 
 import requests

--- a/src/meshapi/util/uisp_import/update_objects.py
+++ b/src/meshapi/util/uisp_import/update_objects.py
@@ -80,7 +80,10 @@ def update_device_from_uisp_data(
         existing_device.abandon_date = uisp_last_seen.date()
         change_messages.append(f"Added missing abandon date of {existing_device.abandon_date} based on UISP last-seen")
 
-    existing_device.save()
+    # Only update the device if we actually changed anything to avoid making
+    # duplicate entries
+    if change_messages:
+        existing_device.save()
 
     if fire_device_deactivated_hook:
         hook_event.send(
@@ -104,7 +107,7 @@ def update_link_from_uisp_data(
 
     if uisp_link_id != existing_link.uisp_id:
         existing_link.uisp_id = uisp_link_id
-        logging.info(
+        change_messages.append(
             f"Changed UISP link ID to {uisp_link_id} for {existing_link} link (ID {existing_link.id}). "
             f"This is likely due to a UISP UUID rotation"
         )
@@ -162,5 +165,8 @@ def update_link_from_uisp_data(
         existing_link.abandon_date = uisp_last_seen.date()
         change_messages.append(f"Added missing abandon date of {existing_link.abandon_date} based on UISP last-seen")
 
-    existing_link.save()
+    # Only save the object if there actually are change_messages, otherwise don't
+    # to avoid creating an unnecessary object.
+    if change_messages:
+        existing_link.save()
     return change_messages


### PR DESCRIPTION
Closes #790 

This prevents the UISP import script from calling save on our objects unnecessarily, which should stop the history tables from ballooning like they do.

See https://django-simple-history.readthedocs.io/en/3.8.0/utils.html#clean-duplicate-history for more info

- [x] Write Tests?