### PR TITLE
use rolling updates for meshdb

### DIFF
--- a/infra/helm/meshdb/templates/meshweb.yaml
+++ b/infra/helm/meshdb/templates/meshweb.yaml
@@ -7,6 +7,11 @@ metadata:
     {{- include "meshdb.labels" . | nindent 4 }}
 spec:
   replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   selector:
     matchLabels:
       {{- include "meshdb.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
This should prevent more than one meshdb pod from coming up/going down at a time when rolling out.

We might want to do something similar for postgres, but I am not sure if that is safe.