### PR TITLE
Hardcode container names

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
   postgres:
+    container_name: meshdb-postgres-1
     healthcheck:
       test: pg_isready -U ${DB_USER}
       interval: 5s
@@ -19,6 +20,7 @@ services:
       - postgres_data:/var/lib/postgresql/data/
 
   redis:
+    container_name: meshdb-redis-1
     healthcheck:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
       interval: 3s
@@ -33,6 +35,7 @@ services:
       - 6379:6379
 
   pelias:
+    container_name: meshdb-pelias-1
     networks:
       - api
     ports:
@@ -40,6 +43,7 @@ services:
     image: pelias/parser
 
   meshdb:
+    container_name: meshdb-meshdb-1
     depends_on:
       postgres:
         condition: service_healthy
@@ -64,6 +68,7 @@ services:
       dockerfile: ./Dockerfile
 
   nginx:
+    container_name: meshdb-nginx-1
     depends_on:
       meshdb:
         condition: service_healthy
@@ -81,6 +86,7 @@ services:
       - static_files:/var/www/html/static
 
   minio:
+    container_name: meshdb-minio-1
     image: quay.io/minio/minio
     ports:
       - '9000:9000'
@@ -98,6 +104,7 @@ services:
 
   # I hate computers: https://github.com/minio/minio/issues/4769
   createbuckets:
+    container_name: meshdb-createbuckets-1
     image: minio/mc
     depends_on:
       - minio


### PR DESCRIPTION
One dev was having issues with names on their containers interfering with the functionality of some of our scripts. This hardcodes the names to those expected to resolve those issues.