### PR TITLE
allow install_fee_billing_datum to be null on install serializer

### DIFF
--- a/src/meshapi/serializers/model_api.py
+++ b/src/meshapi/serializers/model_api.py
@@ -54,6 +54,7 @@ class InstallSerializer(NestedKeyRelatedMixIn, serializers.ModelSerializer):
 
     request_date = serializers.DateTimeField(default_timezone=timezone.utc)
     install_fee_billing_datum = NestedKeyObjectRelatedField(
+        allow_null=True,
         read_only=True,
         additional_keys_display_permission="meshapi.view_installfeebillingdatum",
         additional_keys=(


### PR DESCRIPTION
I was running into problems with pymeshdb. It was giving me errors because there was no billing data on every install object. This will hopefully let us get around that.

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Install
install_fee_billing_datum
  Input should be a valid dictionary or instance of InstallInstallFeeBillingDatum [type=model_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/model_type
```