### PR TITLE
Fix: active links can be hidden by inactive ones

### DIFF
--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -1711,6 +1711,69 @@ class TestViewsGetUnauthenticated(TestCase):
             ],
         )
 
+    def test_inactive_duplicate_link_doesnt_hide_active_one(self):
+        node1 = Node(
+            name="Hub ABC",
+            network_number=123,
+            status=Node.NodeStatus.ACTIVE,
+            latitude=40.724868,
+            longitude=-73.987881,
+            type=Node.NodeType.HUB,
+        )
+        node1.save()
+        device1 = Device(
+            node=node1,
+            status=Device.DeviceStatus.ACTIVE,
+        )
+        device1.save()
+
+        node2 = Node(
+            name="Hub DEF",
+            network_number=456,
+            status=Node.NodeStatus.ACTIVE,
+            latitude=40.724868,
+            longitude=-73.987881,
+            type=Node.NodeType.HUB,
+        )
+        node2.save()
+        device2 = Device(
+            node=node2,
+            status=Device.DeviceStatus.ACTIVE,
+        )
+        device2.save()
+
+        link1 = Link(
+            id="1a3bfc0d-0967-4a9d-88f4-166616d6d2d6",
+            from_device=device1,
+            to_device=device2,
+            status=Link.LinkStatus.INACTIVE,
+            type=Link.LinkType.FIVE_GHZ,
+        )
+        link1.save()
+
+        link2 = Link(
+            id="ff647a56-44ce-4328-889c-345b4b408858",
+            from_device=device1,
+            to_device=device2,
+            status=Link.LinkStatus.ACTIVE,
+            type=Link.LinkType.ETHERNET,
+        )
+        link2.save()
+
+        self.maxDiff = None
+        response = self.c.get("/api/v1/mapdata/links/")
+
+        self.assertEqual(
+            json.loads(response.content.decode("UTF8")),
+            [
+                {
+                    "from": 123,
+                    "to": 456,
+                    "status": "active",
+                },
+            ],
+        )
+
 
 class TestKiosk(TestCase):
     c = Client()

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -211,6 +211,9 @@ class MapDataLinkList(generics.ListAPIView):
                             from_device__node__network_number=OuterRef("from_device__node__network_number"),
                             to_device__node__network_number=OuterRef("to_device__node__network_number"),
                         )
+                        .exclude(status__in=[Link.LinkStatus.INACTIVE])
+                        .exclude(to_device__node__status=Node.NodeStatus.INACTIVE)
+                        .exclude(from_device__node__status=Node.NodeStatus.INACTIVE)
                         .order_by("pk")
                         .values("pk")[:1]
                     )


### PR DESCRIPTION
Small bug in our map link de-duplication logic results in inactive links with lower PKs being able to "hide" active links between the same node pair, since the inactive link "wins" in the sub-query but then gets fitered out in the parent query. Also adds a regression test

SQL is hard 😵‍💫

Original bug report here: https://nycmesh.slack.com/archives/C06GW3Q92TY/p1743660299172189