### PR TITLE
No restart

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -90,9 +90,5 @@ jobs:
         --set meshweb.image.digest="${{ inputs.image_digest }}" \
         --set celery.image.digest="${{ inputs.image_digest }}"
 
-        # Rolling restart
-        kubectl --kubeconfig ./config --server https://${{ secrets.SSH_TARGET_IP }}:6443 -n ${{ vars.APP_NAMESPACE }} rollout restart deploy
-        kubectl --kubeconfig ./config --server https://${{ secrets.SSH_TARGET_IP }}:6443 -n ${{ vars.APP_NAMESPACE }} rollout restart statefulset
-        
         # Wait for deploy to complete
         kubectl --kubeconfig ./config --server https://${{ secrets.SSH_TARGET_IP }}:6443 -n ${{ vars.APP_NAMESPACE }} rollout status deployment --timeout 30m


### PR DESCRIPTION
We don't need to restart anymore because the images referenced by the deployments will be bounced if the image digest changes (always).