### PR TITLE
Celery per-container resources

### DIFF
--- a/infra/helm/meshdb/templates/celery.yaml
+++ b/infra/helm/meshdb/templates/celery.yaml
@@ -41,7 +41,7 @@ spec:
           {{- end }}
           imagePullPolicy: {{ $.Values.celery.image.pullPolicy }}
           resources:
-            {{- toYaml $.Values.celery.resources | nindent 12 }}
+            {{- toYaml .resources | nindent 12 }}
           command: {{ toJson .command }}
           env:
           - name: DD_SERVICE

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -206,7 +206,7 @@ celery:
           memory: 2Gi
         requests:
           cpu: 100m
-          memory: 512Mi
+          memory: 2Gi
     - name: celery-beat
       command: 
         - sh

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -234,8 +234,8 @@ celery:
         timeoutSeconds: 10
       resources:
         limits:
-          cpu: 1
-          memory: 2Gi
+          cpu: 250m
+          memory: 512Mi
         requests:
           cpu: 100m
-          memory: 512Mi
+          memory: 256Mi

--- a/infra/helm/meshdb/values.yaml
+++ b/infra/helm/meshdb/values.yaml
@@ -174,14 +174,6 @@ celery:
   ingress:
     enabled: false
 
-  resources:
-    limits:
-      cpu: 1
-      memory: 2Gi
-    requests:
-      cpu: 100m
-      memory: 512Mi
-
   containers:
     - name: celery-worker
       command:
@@ -208,6 +200,13 @@ celery:
         initialDelaySeconds: 60
         periodSeconds: 60
         timeoutSeconds: 10
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
     - name: celery-beat
       command: 
         - sh
@@ -233,3 +232,10 @@ celery:
         initialDelaySeconds: 60
         periodSeconds: 60
         timeoutSeconds: 10
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi


### PR DESCRIPTION
Resolves https://github.com/nycmeshnet/meshdb/issues/893 by making resource requests+limits per-container for celery because in practice the resource usage is pretty lopsided.

Don't hesitate to make suggestions on the values.