### PR TITLE
Don't schedule celery on the control plane!

### DIFF
--- a/infra/helm/meshdb/templates/celery.yaml
+++ b/infra/helm/meshdb/templates/celery.yaml
@@ -23,6 +23,16 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: NotIn
+                values:
+                - "true"
       {{- if .Values.imageCredentials }}
       imagePullSecrets:
         - name: pull-secret
@@ -45,7 +55,7 @@ spec:
           command: {{ toJson .command }}
           env:
           - name: DD_SERVICE
-            value: celery 
+            value: celery
           # TODO (willnilges): Fix this in a later PR.
           #  https://github.com/nycmeshnet/meshdb/issues/519
           envFrom:


### PR DESCRIPTION
This adds an affinity that should prevent celery pods from getting deployed on the control plane. If this works, I'll do it with our other "heavy" pods too.