### PR TITLE
fix link highlight not acting as link

### DIFF
--- a/src/meshweb/static/meshweb/styles.css
+++ b/src/meshweb/static/meshweb/styles.css
@@ -94,7 +94,7 @@ footer a {
   padding: 16px 10px;
 }
 
-.toolListItem a {
+.toolListLink {
   text-decoration: none;
 }
 

--- a/src/meshweb/templates/meshweb/index.html
+++ b/src/meshweb/templates/meshweb/index.html
@@ -36,9 +36,11 @@
           <h5>{{ category.1 }}</h5>
         </div>
         {% for link, description in tools %}
+        <a class="toolListLink" href={{ link }}>
         <div class="toolListItem">
-        <a href={{ link }}><h6>{{ description }}</h6></a>
+        <h6>{{ description }}</h6>
         </div>
+        </a>
         {% endfor %}
       </div>
       {% endfor %}


### PR DESCRIPTION
This enables the highlight around the links on the admin panel to be clickable.
![image](https://github.com/user-attachments/assets/d0e076fe-621e-458c-9f91-11b09f5f93fe)
