### PR TITLE
Add ability to search for additional members in query form

### DIFF
--- a/src/meshapi/tests/test_query_form.py
+++ b/src/meshapi/tests/test_query_form.py
@@ -21,12 +21,17 @@ class TestQueryForm(TestCase):
         member.save()
         sample_install_copy["member"] = member
 
+        self.additional_member = Member(**sample_member)
+        self.additional_member.name = "Jane Doe"
+        self.additional_member.save()
+
         node = Node(latitude=0, longitude=0, status=Node.NodeStatus.ACTIVE)
         node.save()
 
         self.install = Install(**sample_install_copy)
         self.install.node = node
         self.install.save()
+        self.install.additional_members.add(self.additional_member)
 
     def query(self, route, field, data):
         code = 200
@@ -41,7 +46,11 @@ class TestQueryForm(TestCase):
         )
 
         resp_json = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(len(resp_json["results"]), 1)
+        self.assertEqual(len(resp_json["results"]), 2)
+
+        # Check that we are correctly multiplying the Install row for each additional member
+        discovered_names = {row["name"] for row in resp_json["results"]}
+        self.assertEqual(discovered_names, {"John Smith", "Jane Doe"})
 
     def test_query_address(self):
         self.query("buildings", "street_address", self.install.building.street_address)
@@ -51,6 +60,9 @@ class TestQueryForm(TestCase):
 
     def test_query_name(self):
         self.query("members", "name", self.install.member.name)
+
+    def test_query_additional_name(self):
+        self.query("members", "name", self.additional_member.name)
 
     def test_query_nn(self):
         self.query("installs", "network_number", self.install.node.network_number)


### PR DESCRIPTION
Adds the ability to search for fields on the additional members attached to an install. However, in order to make the response make sense, we need a way to expose the additional members in the response.

My solution to this was to replicate the appearance of a SQL join, but with Django model objects. If your query hits an install that has additional members, it will show up in the output multiple times. So it will look something like

```
#1234, John Smith, NN123....
#1234, Jane Doe, NN123....
```

And this "block" of two rows will be returned for queries to `NN123`, `#1234`, or either `John Smith` or `Jane Doe` it effectively moves the unit of query from the install to a "fake group" of installs that are duplicated based on the number of additional members.

**Is this a good idea?** 
_Query form, bottom text_

Closes #912 