### PR TITLE
added node to autocomplete fields

### DIFF
--- a/src/meshapi/admin/models/install.py
+++ b/src/meshapi/admin/models/install.py
@@ -107,7 +107,7 @@ class InstallAdmin(RankedSearchMixin, ImportExportMixin, ExportActionMixin, Simp
         + SearchVector("referral", weight="D")
         + SearchVector("notes", weight="D")
     )
-    autocomplete_fields = ["building", "member"]
+    autocomplete_fields = ["building", "member", "node"]
     readonly_fields = ["install_number"]
     fieldsets = [
         (


### PR DESCRIPTION
Addressed [issue](https://github.com/nycmeshnet/meshdb/issues/925) by adding auto complete searching to the nodes field when adding/editing installs.