### PR TITLE
fix error when users view installs without admin or installer permiss…

### DIFF
--- a/src/meshapi/admin/models/install.py
+++ b/src/meshapi/admin/models/install.py
@@ -57,7 +57,9 @@ class InstallAdminForm(forms.ModelForm):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.fields["status"].widget.form_instance = self
+
+        if "status" in self.fields:
+            self.fields["status"].widget.form_instance = self
 
 
 @admin.register(Install)


### PR DESCRIPTION
…ions

issue:
https://github.com/nycmeshnet/meshdb/issues/901

this is a naive solution. i just checked if the key was in the dictionary before using it. let me know if this isn't the right approach.

but maybe someone can walk me through what's happening in the django code.

what happens when someone tries to view the install page with admin privileges:

![Screenshot from 2025-06-26 13-51-40](https://github.com/user-attachments/assets/056dd954-9d60-46ae-81d5-2ebe8e2f7c96)

what happens when someone tries to view the install page with read only privileges before the pr:

![Screenshot from 2025-06-26 13-49-32](https://github.com/user-attachments/assets/f5f72be9-d7fd-43fa-adf8-6e3b5756acfe)

what happens when someone tries to view the install page with read only privileges after the pr:

![Screenshot from 2025-06-26 13-49-51](https://github.com/user-attachments/assets/3e50818e-2224-4fb8-9400-b1fa00625761)
