### PR TITLE
stop deploying to prod2

### DIFF
--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -54,12 +54,12 @@ jobs:
     needs: [push_to_registry_prod, integration_test_dev3]
     if: github.ref == 'refs/heads/main'
 
-  deploy_to_prod2:
-    name: Deploy to prod2
-    uses: ./.github/workflows/deploy-to-k8s.yaml
-    with:
-      environment: prod2
-      image_digest: ${{ needs.push_to_registry_prod.outputs.image_digest }}
-    secrets: inherit
-    needs: [push_to_registry_prod, deploy_to_prod1]
-    if: github.ref == 'refs/heads/main'
+  #deploy_to_prod2:
+  #  name: Deploy to prod2
+  #  uses: ./.github/workflows/deploy-to-k8s.yaml
+  #  with:
+  #    environment: prod2
+  #    image_digest: ${{ needs.push_to_registry_prod.outputs.image_digest }}
+  #  secrets: inherit
+  #  needs: [push_to_registry_prod, deploy_to_prod1]
+  #  if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
prod2 is very sad and gets into CLB a lot when you deploy, so stop doing it.