### PR TITLE
Add pgsql-http extension to our database

### DIFF
--- a/.github/workflows/build-push-image.yaml
+++ b/.github/workflows/build-push-image.yaml
@@ -10,6 +10,12 @@ on:
       image_tag:
         required: true
         type: string
+      dockerfile:
+        required: true
+        type: string
+      image_metadata:
+        required: true
+        type: string
     outputs:
       image_digest:
         description: "Digest of the built image"
@@ -25,25 +31,25 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      
+
       - name: Log in to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: willnilges/meshdb
-      
+          images: ${{ inputs.image_metadata }}
+
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
-          file: ./Dockerfile
+          file: ${{ inputs.dockerfile }}
           push: true
           tags: ${{ inputs.image_tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -22,6 +22,19 @@ jobs:
     with:
       environment: prod
       image_tag: willnilges/meshdb:main
+      dockerfile: ./
+      image_metadata: willnilges/meshdb
+    secrets: inherit
+    if: github.ref == 'refs/heads/main'
+
+  push_to_registry_prod:
+    name: Push custom postgres image
+    uses: ./.github/workflows/build-push-image.yaml
+    with:
+      environment: prod
+      image_tag: willnilges/postgres-pgsql-http:main
+      dockerfile: ./scripts/postgres-pgsql-http/Dockerfile
+      image_metadata: willnilges/postgres-pgsql-http
     secrets: inherit
     if: github.ref == 'refs/heads/main'
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,9 @@ services:
       - api
     ports:
       - 5432:5432
-    image: docker.io/postgres:15-bookworm
+    build:
+      context: .
+      dockerfile: ./scripts/postgres-pgsql-http/Dockerfile
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USER}

--- a/scripts/postgres-pgsql-http/Dockerfile
+++ b/scripts/postgres-pgsql-http/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/postgres:15-bookworm
+
+RUN apt update && apt install -y postgresql-15-http


### PR DESCRIPTION
Will need to `CREATE EXTENSION http` when this is merged.

Candidate for closing https://github.com/nycmeshnet/meshdb/issues/639

This could also increase our attack surface quite a bit. I wonder if there is a way to restrict what URLs we can query.