### PR TITLE
add links to download KML files

### DIFF
--- a/src/meshweb/views/index.py
+++ b/src/meshweb/views/index.py
@@ -29,7 +29,10 @@ def index(request: HttpRequest) -> HttpResponse:
             ("/api/v1/", "MeshDB Data API"),
             ("/api-docs/swagger/", "API Docs (Swagger)"),
             ("/api-docs/redoc/", "API Docs (Redoc)"),
-            ("https://raw.githubusercontent.com/nycmeshnet/meshdb/refs/heads/main/sampledata/meshdb_local.kml", "KML Download (Localdev)"),
+            (
+                "https://raw.githubusercontent.com/nycmeshnet/meshdb/refs/heads/main/sampledata/meshdb_local.kml",
+                "KML Download (Localdev)",
+            ),
         ],
     }
     context = {"links": links, "logo": "meshweb/logo.svg"}


### PR DESCRIPTION
Adds two new links to the homepage that lets you download a KML that is updated "live" by meshdb, as well as one that links to your local copy of meshdb. The existing KML was renamed to "KML Download (Offline)"

![image](https://github.com/user-attachments/assets/79d107f8-d206-4c91-bc68-893aed937a1a)
