### PR TITLE
Handle edge case with stats calculation

### DIFF
--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -156,12 +156,12 @@ class TestWebsiteStatsGraph(TestCase):
         self.assertEqual(svg_response.status_code, 400)
 
     def test_graph_svg_looks_roughly_right(self):
-        # svg_response = self.client.get("/website-embeds/stats-graph.svg?data=active_installs&days=0")
-        # self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?data=active_installs&days=0")
+        self.assertEqual(svg_response.status_code, 200)
 
-        # self.assertContains(svg_response, ">3</text>")
-        # self.assertContains(svg_response, ">Nov 15, 2023</text>")
-        # self.assertContains(svg_response, ">Nov 16, 2024</text>")
+        self.assertContains(svg_response, ">3</text>")
+        self.assertContains(svg_response, ">Feb 27, 2022</text>")
+        self.assertContains(svg_response, ">Nov 16, 2024</text>")
 
         svg_response = self.client.get("/website-embeds/stats-graph.svg?data=active_installs&days=365")
         self.assertEqual(svg_response.status_code, 200)
@@ -170,12 +170,12 @@ class TestWebsiteStatsGraph(TestCase):
         self.assertContains(svg_response, ">Nov 17, 2023</text>")
         self.assertContains(svg_response, ">Nov 16, 2024</text>")
 
-        # svg_response = self.client.get("/website-embeds/stats-graph.svg?data=install_requests&days=0")
-        # self.assertEqual(svg_response.status_code, 200)
+        svg_response = self.client.get("/website-embeds/stats-graph.svg?data=install_requests&days=0")
+        self.assertEqual(svg_response.status_code, 200)
 
-        # self.assertContains(svg_response, ">4</text>")
-        # self.assertContains(svg_response, ">Oct 16, 2024</text>")
-        # self.assertContains(svg_response, ">Nov 16, 2024</text>")
+        self.assertContains(svg_response, ">4</text>")
+        self.assertContains(svg_response, ">Feb 27, 2022</text>")
+        self.assertContains(svg_response, ">Nov 16, 2024</text>")
 
         svg_response = self.client.get("/website-embeds/stats-graph.svg?data=install_requests&days=31")
         self.assertEqual(svg_response.status_code, 200)

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -33,89 +33,89 @@ class TestWebsiteStatsGraph(TestCase):
         self.install1.save()
 
         # Install - Status = Request Received during period
-        self.install2 = Install(
+        self.install32 = Install(
             **self.sample_install_copy,
-            install_number=2,
+            install_number=32,
             building=self.building_1,
             member=self.member,
         )
-        self.install2.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install2.request_date = "2024-11-15T00:00:00Z"
-        self.install2.save()
+        self.install32.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install32.request_date = "2024-11-15T00:00:00Z"
+        self.install32.save()
 
         # Install - Status = Request Received at last day of period
-        self.install3 = Install(
+        self.install33 = Install(
             **self.sample_install_copy,
-            install_number=3,
+            install_number=33,
             building=self.building_1,
             member=self.member,
         )
-        self.install3.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install3.request_date = "2024-11-16T00:00:00Z"
-        self.install3.save()
+        self.install33.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install33.request_date = "2024-11-16T00:00:00Z"
+        self.install33.save()
 
         # Install - Status = Request Received after period
-        self.install4 = Install(
+        self.install34 = Install(
             **self.sample_install_copy,
-            install_number=4,
+            install_number=34,
             building=self.building_1,
             member=self.member,
         )
-        self.install4.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install4.request_date = "2024-11-17T00:00:00Z"
-        self.install4.save()
+        self.install34.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install34.request_date = "2024-11-17T00:00:00Z"
+        self.install34.save()
 
         # ----------------------Active----------------------
 
         # Install - Status = Active, Created before 365 days
-        self.install5 = Install(
+        self.install35 = Install(
             **self.sample_install_copy,
-            install_number=5,
+            install_number=35,
             building=self.building_1,
             member=self.member,
         )
-        self.install5.install_date = "2023-11-15"
-        self.install5.save()
+        self.install35.install_date = "2023-11-15"
+        self.install35.save()
 
         # Install - Status = Active, Created during period
-        self.install6 = Install(
+        self.install36 = Install(
             **self.sample_install_copy,
-            install_number=6,
+            install_number=36,
             building=self.building_1,
             member=self.member,
         )
-        self.install6.install_date = "2024-11-12"
-        self.install6.save()
+        self.install36.install_date = "2024-11-12"
+        self.install36.save()
 
         # Install - Status = Active, Created at last day of period
-        self.install7 = Install(
+        self.install37 = Install(
             **self.sample_install_copy,
-            install_number=7,
+            install_number=37,
             building=self.building_1,
             member=self.member,
         )
-        self.install7.install_date = "2024-11-16"
-        self.install7.save()
+        self.install37.install_date = "2024-11-16"
+        self.install37.save()
 
         # Install - Status = Active, Created after period
-        self.install8 = Install(
+        self.install38 = Install(
             **self.sample_install_copy,
-            install_number=8,
+            install_number=38,
             building=self.building_1,
             member=self.member,
         )
-        self.install8.install_date = "2024-11-17"
-        self.install8.save()
+        self.install38.install_date = "2024-11-17"
+        self.install38.save()
 
     def test_empty_db(self):
         self.install1.delete()
-        self.install2.delete()
-        self.install3.delete()
-        self.install4.delete()
-        self.install5.delete()
-        self.install6.delete()
-        self.install7.delete()
-        self.install8.delete()
+        self.install32.delete()
+        self.install33.delete()
+        self.install34.delete()
+        self.install35.delete()
+        self.install36.delete()
+        self.install37.delete()
+        self.install38.delete()
         svg_response = self.client.get("/website-embeds/stats-graph.svg")
         self.assertContains(svg_response, "No installs found, is the database empty?", status_code=500)
 

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -40,7 +40,30 @@ class TestWebsiteStatsGraph(TestCase):
             member=self.member,
         )
         self.install2.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install2.request_date = '2024-11-15T00:00:00Z'
         self.install2.save()
+
+        # Install - Status = Request Received at last day of period
+        self.install10 = Install(
+            **self.sample_install_copy,
+            install_number=10,
+            building=self.building_1,
+            member=self.member,
+        )
+        self.install10.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install10.request_date = '2024-11-16T00:00:00Z'
+        self.install10.save()
+
+        # Install - Status = Request Received after period
+        self.install11 = Install(
+            **self.sample_install_copy,
+            install_number=11,
+            building=self.building_1,
+            member=self.member,
+        )
+        self.install11.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install11.request_date = '2024-11-17T00:00:00Z'
+        self.install11.save()
 
         # ----------------------Active----------------------
 
@@ -155,7 +178,7 @@ class TestWebsiteStatsGraph(TestCase):
         svg_response = self.client.get("/website-embeds/stats-graph.svg?data=install_requests&days=31")
         self.assertEqual(svg_response.status_code, 200)
 
-        self.assertContains(svg_response, ">6</text>")
+        self.assertContains(svg_response, ">7</text>")
         self.assertContains(svg_response, ">Oct 16, 2024</text>")
         self.assertContains(svg_response, ">Nov 16, 2024</text>")
 

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -32,7 +32,7 @@ class TestWebsiteStatsGraph(TestCase):
         self.install1.request_date = "2024-10-15T00:00:00Z"
         self.install1.save()
 
-        # Install - Status = Request Received during period
+        # Install - Status = Request Received, Created during period
         self.install32 = Install(
             **self.sample_install_copy,
             install_number=32,
@@ -43,7 +43,7 @@ class TestWebsiteStatsGraph(TestCase):
         self.install32.request_date = "2024-11-15T00:00:00Z"
         self.install32.save()
 
-        # Install - Status = Request Received at last day of period
+        # Install - Status = Request Received, Created at last day of period
         self.install33 = Install(
             **self.sample_install_copy,
             install_number=33,
@@ -54,7 +54,7 @@ class TestWebsiteStatsGraph(TestCase):
         self.install33.request_date = "2024-11-16T00:00:00Z"
         self.install33.save()
 
-        # Install - Status = Request Received after period
+        # Install - Status = Request Received, Created after period
         self.install34 = Install(
             **self.sample_install_copy,
             install_number=34,

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -159,7 +159,8 @@ class TestWebsiteStatsGraph(TestCase):
         svg_response = self.client.get("/website-embeds/stats-graph.svg?data=active_installs&days=0")
         self.assertEqual(svg_response.status_code, 200)
 
-        self.assertContains(svg_response, ">3</text>")
+        self.assertContains(svg_response, ">0</text>")
+        self.assertContains(svg_response, ">2</text>")
         self.assertContains(svg_response, ">Feb 27, 2022</text>")
         self.assertContains(svg_response, ">Nov 16, 2024</text>")
 
@@ -167,6 +168,7 @@ class TestWebsiteStatsGraph(TestCase):
         self.assertEqual(svg_response.status_code, 200)
 
         self.assertContains(svg_response, ">1</text>")
+        self.assertContains(svg_response, ">2</text>")
         self.assertContains(svg_response, ">Nov 17, 2023</text>")
         self.assertContains(svg_response, ">Nov 16, 2024</text>")
 
@@ -174,13 +176,15 @@ class TestWebsiteStatsGraph(TestCase):
         self.assertEqual(svg_response.status_code, 200)
 
         self.assertContains(svg_response, ">4</text>")
+        self.assertContains(svg_response, ">6</text>")
         self.assertContains(svg_response, ">Feb 27, 2022</text>")
         self.assertContains(svg_response, ">Nov 16, 2024</text>")
 
         svg_response = self.client.get("/website-embeds/stats-graph.svg?data=install_requests&days=31")
         self.assertEqual(svg_response.status_code, 200)
 
-        self.assertContains(svg_response, ">7</text>")
+        self.assertContains(svg_response, ">5</text>")
+        self.assertContains(svg_response, ">6</text>")
         self.assertContains(svg_response, ">Oct 16, 2024</text>")
         self.assertContains(svg_response, ">Nov 16, 2024</text>")
 

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -44,68 +44,68 @@ class TestWebsiteStatsGraph(TestCase):
         self.install2.save()
 
         # Install - Status = Request Received at last day of period
-        self.install10 = Install(
-            **self.sample_install_copy,
-            install_number=10,
-            building=self.building_1,
-            member=self.member,
-        )
-        self.install10.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install10.request_date = '2024-11-16T00:00:00Z'
-        self.install10.save()
-
-        # Install - Status = Request Received after period
-        self.install11 = Install(
-            **self.sample_install_copy,
-            install_number=11,
-            building=self.building_1,
-            member=self.member,
-        )
-        self.install11.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install11.request_date = '2024-11-17T00:00:00Z'
-        self.install11.save()
-
-        # ----------------------Active----------------------
-
-        # Install - Status = Active, Created before 365 days
         self.install3 = Install(
             **self.sample_install_copy,
             install_number=3,
             building=self.building_1,
             member=self.member,
         )
-        self.install3.install_date = '2023-11-15'
+        self.install3.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install3.request_date = '2024-11-16T00:00:00Z'
         self.install3.save()
 
-        # Install - Status = Active, Created during period
+        # Install - Status = Request Received after period
         self.install4 = Install(
             **self.sample_install_copy,
             install_number=4,
             building=self.building_1,
             member=self.member,
         )
-        self.install4.install_date = '2024-11-12'
+        self.install4.status = Install.InstallStatus.REQUEST_RECEIVED
+        self.install4.request_date = '2024-11-17T00:00:00Z'
         self.install4.save()
 
-        # Install - Status = Active, Created at last day of period
+        # ----------------------Active----------------------
+
+        # Install - Status = Active, Created before 365 days
         self.install5 = Install(
             **self.sample_install_copy,
             install_number=5,
             building=self.building_1,
             member=self.member,
         )
-        self.install5.install_date = '2024-11-16'
+        self.install5.install_date = '2023-11-15'
         self.install5.save()
 
-        # Install - Status = Active, Created after period
+        # Install - Status = Active, Created during period
         self.install6 = Install(
             **self.sample_install_copy,
             install_number=6,
             building=self.building_1,
             member=self.member,
         )
-        self.install6.install_date = '2024-11-17'
+        self.install6.install_date = '2024-11-12'
         self.install6.save()
+
+        # Install - Status = Active, Created at last day of period
+        self.install7 = Install(
+            **self.sample_install_copy,
+            install_number=7,
+            building=self.building_1,
+            member=self.member,
+        )
+        self.install7.install_date = '2024-11-16'
+        self.install7.save()
+
+        # Install - Status = Active, Created after period
+        self.install8 = Install(
+            **self.sample_install_copy,
+            install_number=8,
+            building=self.building_1,
+            member=self.member,
+        )
+        self.install8.install_date = '2024-11-17'
+        self.install8.save()
 
     def test_empty_db(self):
         self.install1.delete()
@@ -114,6 +114,8 @@ class TestWebsiteStatsGraph(TestCase):
         self.install4.delete()
         self.install5.delete()
         self.install6.delete()
+        self.install7.delete()
+        self.install8.delete()
         svg_response = self.client.get("/website-embeds/stats-graph.svg")
         self.assertContains(svg_response, "No installs found, is the database empty?", status_code=500)
 

--- a/src/meshapi/tests/test_website_stats.py
+++ b/src/meshapi/tests/test_website_stats.py
@@ -29,7 +29,7 @@ class TestWebsiteStatsGraph(TestCase):
             member=self.member,
         )
         self.install1.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install1.request_date = '2024-10-15T00:00:00Z'
+        self.install1.request_date = "2024-10-15T00:00:00Z"
         self.install1.save()
 
         # Install - Status = Request Received during period
@@ -40,7 +40,7 @@ class TestWebsiteStatsGraph(TestCase):
             member=self.member,
         )
         self.install2.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install2.request_date = '2024-11-15T00:00:00Z'
+        self.install2.request_date = "2024-11-15T00:00:00Z"
         self.install2.save()
 
         # Install - Status = Request Received at last day of period
@@ -51,7 +51,7 @@ class TestWebsiteStatsGraph(TestCase):
             member=self.member,
         )
         self.install3.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install3.request_date = '2024-11-16T00:00:00Z'
+        self.install3.request_date = "2024-11-16T00:00:00Z"
         self.install3.save()
 
         # Install - Status = Request Received after period
@@ -62,7 +62,7 @@ class TestWebsiteStatsGraph(TestCase):
             member=self.member,
         )
         self.install4.status = Install.InstallStatus.REQUEST_RECEIVED
-        self.install4.request_date = '2024-11-17T00:00:00Z'
+        self.install4.request_date = "2024-11-17T00:00:00Z"
         self.install4.save()
 
         # ----------------------Active----------------------
@@ -74,7 +74,7 @@ class TestWebsiteStatsGraph(TestCase):
             building=self.building_1,
             member=self.member,
         )
-        self.install5.install_date = '2023-11-15'
+        self.install5.install_date = "2023-11-15"
         self.install5.save()
 
         # Install - Status = Active, Created during period
@@ -84,7 +84,7 @@ class TestWebsiteStatsGraph(TestCase):
             building=self.building_1,
             member=self.member,
         )
-        self.install6.install_date = '2024-11-12'
+        self.install6.install_date = "2024-11-12"
         self.install6.save()
 
         # Install - Status = Active, Created at last day of period
@@ -94,7 +94,7 @@ class TestWebsiteStatsGraph(TestCase):
             building=self.building_1,
             member=self.member,
         )
-        self.install7.install_date = '2024-11-16'
+        self.install7.install_date = "2024-11-16"
         self.install7.save()
 
         # Install - Status = Active, Created after period
@@ -104,7 +104,7 @@ class TestWebsiteStatsGraph(TestCase):
             building=self.building_1,
             member=self.member,
         )
-        self.install8.install_date = '2024-11-17'
+        self.install8.install_date = "2024-11-17"
         self.install8.save()
 
     def test_empty_db(self):

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -72,7 +72,7 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
     base_object_queryset = base_object_queryset.filter(status=Install.InstallStatus.ACTIVE)
     object_queryset = base_object_queryset.filter(
         install_date__gte=start_datetime.date(),
-        install_date__lte=end_datetime.date(),
+        install_date__lt=end_datetime.date(),
     )
     buckets[0] = base_object_queryset.filter(install_date__lt=start_datetime).count()
 
@@ -82,12 +82,12 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 
-        if bucket_index >= 0 and bucket_index < 100:
+        if bucket_index > 0 and bucket_index < 100:
             buckets[bucket_index] += 1
         elif bucket_index == 100:
-            buckets[99] += 1
+            continue
         else:
-            raise Exception("Bucket index #{bucket_index} is out of range")
+            raise Exception(f"Bucket index {bucket_index} is out of range")
 
     # Make cumulative
     for i in range(GRAPH_X_AXIS_DATAPOINT_COUNT):
@@ -107,7 +107,7 @@ def compute_graph_stats_for_all_installs(start_datetime: datetime, end_datetime:
 
     object_queryset = base_object_queryset.filter(
         request_date__gte=start_datetime.date(),
-        request_date__lte=end_datetime.date(),
+        request_date__lt=end_datetime.date(),
     )
     buckets[0] = base_object_queryset.filter(request_date__lt=start_datetime).count()
 
@@ -117,12 +117,12 @@ def compute_graph_stats_for_all_installs(start_datetime: datetime, end_datetime:
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 
-        if bucket_index >= 0 and bucket_index < 100:
+        if bucket_index > 0 and bucket_index < 100:
             buckets[bucket_index] += 1
         elif bucket_index == 100:
-            buckets[99] += 1
+            continue
         else:
-            raise Exception("Bucket index #{bucket_index} is out of range")
+            raise Exception(f"Bucket index {bucket_index} is out of range")
 
     # Make cumulative
     for i in range(GRAPH_X_AXIS_DATAPOINT_COUNT):

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -79,6 +79,9 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
     for install in object_queryset:
         counting_date = install.install_date
 
+        if counting_date == None:
+            raise Exception(f"No counting date for install {install.id}")
+
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -53,6 +53,8 @@ def cors_allow_website_stats_to_all(sender: None, request: HttpRequest, **kwargs
 
 
 def compute_graph_stats(data_source: str, start_datetime: datetime, end_datetime: datetime) -> List[int]:
+    # GRAPH_X_AXIS_DATAPOINT_COUNT = 100
+    # buckets is a zero indexed array of length 100.
     buckets = [0 for _ in range(GRAPH_X_AXIS_DATAPOINT_COUNT)]
 
     total_duration_seconds = (end_datetime - start_datetime).total_seconds()
@@ -82,7 +84,13 @@ def compute_graph_stats(data_source: str, start_datetime: datetime, end_datetime
 
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
-        buckets[bucket_index] += 1
+
+        if bucket_index < 100:
+            buckets[bucket_index] += 1
+        elif bucket_index == 100:
+            buckets[99] += 1
+        else:
+            raise Exception('Bucket index #{bucket_index} is out of range')
 
     # Make cumulative
     for i in range(GRAPH_X_AXIS_DATAPOINT_COUNT):

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -58,6 +58,7 @@ def compute_graph_stats(data_source: str, start_datetime: datetime, end_datetime
     else:
         return compute_graph_stats_for_all_installs(start_datetime, end_datetime)
 
+
 def compute_graph_stats_for_active_installs(start_datetime: datetime, end_datetime: datetime) -> List[int]:
     # GRAPH_X_AXIS_DATAPOINT_COUNT = 100
     # buckets is a zero indexed array of length 100.
@@ -86,7 +87,7 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
         elif bucket_index == 100:
             buckets[99] += 1
         else:
-            raise Exception('Bucket index #{bucket_index} is out of range')
+            raise Exception("Bucket index #{bucket_index} is out of range")
 
     # Make cumulative
     for i in range(GRAPH_X_AXIS_DATAPOINT_COUNT):
@@ -94,6 +95,7 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
             buckets[i] += buckets[i - 1]
 
     return buckets
+
 
 def compute_graph_stats_for_all_installs(start_datetime: datetime, end_datetime: datetime) -> List[int]:
     # GRAPH_X_AXIS_DATAPOINT_COUNT = 100
@@ -120,7 +122,7 @@ def compute_graph_stats_for_all_installs(start_datetime: datetime, end_datetime:
         elif bucket_index == 100:
             buckets[99] += 1
         else:
-            raise Exception('Bucket index #{bucket_index} is out of range')
+            raise Exception("Bucket index #{bucket_index} is out of range")
 
     # Make cumulative
     for i in range(GRAPH_X_AXIS_DATAPOINT_COUNT):
@@ -128,6 +130,7 @@ def compute_graph_stats_for_all_installs(start_datetime: datetime, end_datetime:
             buckets[i] += buckets[i - 1]
 
     return buckets
+
 
 def render_graph(
     data_source: str,

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -81,7 +81,7 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 
-        if bucket_index < 100:
+        if bucket_index >= 0 and bucket_index < 100:
             buckets[bucket_index] += 1
         elif bucket_index == 100:
             buckets[99] += 1
@@ -115,7 +115,7 @@ def compute_graph_stats_for_all_installs(start_datetime: datetime, end_datetime:
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 
-        if bucket_index < 100:
+        if bucket_index >= 0 and bucket_index < 100:
             buckets[bucket_index] += 1
         elif bucket_index == 100:
             buckets[99] += 1

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -79,7 +79,7 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
     for install in object_queryset:
         counting_date = install.install_date
 
-        if counting_date == None:
+        if counting_date is None:
             raise Exception(f"No counting date for install {install.id}")
 
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -85,7 +85,9 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 
-        if bucket_index > 0 and bucket_index < 100:
+        if bucket_index == 0:
+            continue
+        elif bucket_index > 0 and bucket_index < 100:
             buckets[bucket_index] += 1
         elif bucket_index == 100:
             continue
@@ -120,7 +122,9 @@ def compute_graph_stats_for_all_installs(start_datetime: datetime, end_datetime:
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 
-        if bucket_index > 0 and bucket_index < 100:
+        if bucket_index == 0:
+            continue
+        elif bucket_index > 0 and bucket_index < 100:
             buckets[bucket_index] += 1
         elif bucket_index == 100:
             continue

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -79,9 +79,6 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
     for install in object_queryset:
         counting_date = install.install_date
 
-        if counting_date is None:
-            continue
-
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -79,6 +79,9 @@ def compute_graph_stats_for_active_installs(start_datetime: datetime, end_dateti
     for install in object_queryset:
         counting_date = install.install_date
 
+        if counting_date is None:
+            continue
+
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
 

--- a/src/meshweb/views/website_stats.py
+++ b/src/meshweb/views/website_stats.py
@@ -53,6 +53,12 @@ def cors_allow_website_stats_to_all(sender: None, request: HttpRequest, **kwargs
 
 
 def compute_graph_stats(data_source: str, start_datetime: datetime, end_datetime: datetime) -> List[int]:
+    if data_source == "active_installs":
+        return compute_graph_stats_for_active_installs(start_datetime, end_datetime)
+    else:
+        return compute_graph_stats_for_all_installs(start_datetime, end_datetime)
+
+def compute_graph_stats_for_active_installs(start_datetime: datetime, end_datetime: datetime) -> List[int]:
     # GRAPH_X_AXIS_DATAPOINT_COUNT = 100
     # buckets is a zero indexed array of length 100.
     buckets = [0 for _ in range(GRAPH_X_AXIS_DATAPOINT_COUNT)]
@@ -60,27 +66,17 @@ def compute_graph_stats(data_source: str, start_datetime: datetime, end_datetime
     total_duration_seconds = (end_datetime - start_datetime).total_seconds()
     base_object_queryset = Install.objects.all()
 
-    if data_source == "active_installs":
-        # FYI This logic doesn't account for installs that have been abandoned,
-        # so it definitely underestimates historical values
-        base_object_queryset = base_object_queryset.filter(status=Install.InstallStatus.ACTIVE)
-        object_queryset = base_object_queryset.filter(
-            install_date__gte=start_datetime.date(),
-            install_date__lte=end_datetime.date(),
-        )
-        buckets[0] = base_object_queryset.filter(install_date__lt=start_datetime).count()
-    else:
-        object_queryset = base_object_queryset.filter(
-            request_date__gte=start_datetime.date(),
-            request_date__lte=end_datetime.date(),
-        )
-        buckets[0] = base_object_queryset.filter(request_date__lt=start_datetime).count()
+    # FYI This logic doesn't account for installs that have been abandoned,
+    # so it definitely underestimates historical values
+    base_object_queryset = base_object_queryset.filter(status=Install.InstallStatus.ACTIVE)
+    object_queryset = base_object_queryset.filter(
+        install_date__gte=start_datetime.date(),
+        install_date__lte=end_datetime.date(),
+    )
+    buckets[0] = base_object_queryset.filter(install_date__lt=start_datetime).count()
 
     for install in object_queryset:
-        if data_source == "active_installs":
-            counting_date = install.install_date or install.request_date.date()
-        else:
-            counting_date = install.request_date.date()
+        counting_date = install.install_date
 
         relative_seconds = (counting_date - start_datetime.date()).total_seconds()
         bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
@@ -99,6 +95,39 @@ def compute_graph_stats(data_source: str, start_datetime: datetime, end_datetime
 
     return buckets
 
+def compute_graph_stats_for_all_installs(start_datetime: datetime, end_datetime: datetime) -> List[int]:
+    # GRAPH_X_AXIS_DATAPOINT_COUNT = 100
+    # buckets is a zero indexed array of length 100.
+    buckets = [0 for _ in range(GRAPH_X_AXIS_DATAPOINT_COUNT)]
+
+    total_duration_seconds = (end_datetime - start_datetime).total_seconds()
+    base_object_queryset = Install.objects.all()
+
+    object_queryset = base_object_queryset.filter(
+        request_date__gte=start_datetime.date(),
+        request_date__lte=end_datetime.date(),
+    )
+    buckets[0] = base_object_queryset.filter(request_date__lt=start_datetime).count()
+
+    for install in object_queryset:
+        counting_date = install.request_date.date()
+
+        relative_seconds = (counting_date - start_datetime.date()).total_seconds()
+        bucket_index = math.floor((relative_seconds / total_duration_seconds) * GRAPH_X_AXIS_DATAPOINT_COUNT)
+
+        if bucket_index < 100:
+            buckets[bucket_index] += 1
+        elif bucket_index == 100:
+            buckets[99] += 1
+        else:
+            raise Exception('Bucket index #{bucket_index} is out of range')
+
+    # Make cumulative
+    for i in range(GRAPH_X_AXIS_DATAPOINT_COUNT):
+        if i > 0:
+            buckets[i] += buckets[i - 1]
+
+    return buckets
 
 def render_graph(
     data_source: str,


### PR DESCRIPTION
pr for this ticket https://github.com/nycmeshnet/meshdb/issues/950

the code creates an array of size 100, where the index represents a time period between the start_time and end_time parameters, and the value represents the total number of active installs or all installs during that time period.

we retrieve the installs to populate the counts in the array with these queries
- https://github.com/nycmeshnet/meshdb/blob/main/src/meshweb/views/website_stats.py#L65
- https://github.com/nycmeshnet/meshdb/blob/main/src/meshweb/views/website_stats.py#L71

they filter for installs between the start_time and end_time with some other conditional params

it's currently breaking when an edge case causes us to index into the array out of range.

i believe there are three situations where that can occur

- we use the request date on an install instead of the install date and the request date is before start_time (i don't think this would actually occur b/c how can install date every be null if we are filtering based on it in the db query?)
-- https://github.com/nycmeshnet/meshdb/blob/main/src/meshweb/views/website_stats.py#L79

- the request date is the same as the end_time parameter which would cause is to index into the array at index 100
-- https://github.com/nycmeshnet/meshdb/blob/main/src/meshweb/views/website_stats.py#L84

- the install date is the same as the end_time parameter which would cause is to index into the array at index 100
-- https://github.com/nycmeshnet/meshdb/blob/main/src/meshweb/views/website_stats.py#L84

my fix is to index into the array at the last position 99 when the request date or install date are the same as the end_time parameter

i also separated the code paths for generating buckets for active installs vs all installs to make it clearer how the queries for each worked at the expense of keeping the code "dry".

this is super edge case-y. happy to write a test if needed.

also, i could be wrong and the error could be caused by something else.