### PR TITLE
Fix entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY ./src/meshweb/static .
 
 COPY ./src .
 
-ENTRYPOINT ./scripts/entrypoint.sh && exec ddtrace-run gunicorn 'meshdb.wsgi' --workers 4 --timeout 120 --graceful-timeout 2 --bind=0.0.0.0:8081
+ENTRYPOINT ["sh", "-c", "./scripts/entrypoint.sh && exec ddtrace-run gunicorn 'meshdb.wsgi' --workers 4 --timeout 120 --graceful-timeout 2 --bind=0.0.0.0:8081"]


### PR DESCRIPTION
Make the dockerfile linter happy


> JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals: Dockerfile#L21
JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals
More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/


https://github.com/nycmeshnet/meshdb/actions/runs/16015550396