### PR TITLE
Always schedule backup task

### DIFF
--- a/src/meshapi/tasks.py
+++ b/src/meshapi/tasks.py
@@ -37,10 +37,6 @@ def run_uisp_on_demand_import(target_nn: int) -> None:
 @celery_app.task
 @skip_if_flag_disabled("TASK_ENABLED_RUN_DATABASE_BACKUP")
 def run_database_backup() -> None:
-    # Don't run a backup unless it's prod
-    if MESHDB_ENVIRONMENT != "prod":  # This is bad but this is a temporary change
-        raise EnvironmentError(f'Not running database backup. This environment is: "{MESHDB_ENVIRONMENT}"')
-
     logging.info(f'Running database backup task. This environment is "{MESHDB_ENVIRONMENT}"')
     if not os.environ.get("AWS_ACCESS_KEY_ID") or not os.environ.get("AWS_SECRET_ACCESS_KEY"):
         raise ValueError("Could not run backup. Missing AWS credentials!")

--- a/src/meshapi/tasks.py
+++ b/src/meshapi/tasks.py
@@ -127,11 +127,10 @@ celery_app.conf.beat_schedule = {
     },
 }
 
-if MESHDB_ENVIRONMENT == "prod2":
-    celery_app.conf.beat_schedule["run-database-backup-hourly"] = {
-        "task": "meshapi.tasks.run_database_backup",
-        "schedule": crontab(minute="40", hour="*/1"),
-    }
+celery_app.conf.beat_schedule["run-database-backup-hourly"] = {
+    "task": "meshapi.tasks.run_database_backup",
+    "schedule": crontab(minute="40", hour="*/1"),
+}
 
 if MESHDB_ENVIRONMENT == "dev3":
     celery_app.conf.beat_schedule["run-reset-dev-database-daily"] = {

--- a/src/meshapi/tests/test_tasks.py
+++ b/src/meshapi/tests/test_tasks.py
@@ -22,11 +22,13 @@ class TestRunDatabaseBackupTask(TestCase):
     @mock.patch("django.core.management.call_command")
     @mock.patch("meshapi.tasks.MESHDB_ENVIRONMENT", "dev3")
     def test_run_database_backup_not_prod(self, mock_call_command_func):
+        # This test will pass because dev is allowed to run backups. We should
+        # be careful to keep that flag turned off in dev.
         os.environ["AWS_ACCESS_KEY_ID"] = "fake"
         os.environ["AWS_SECRET_ACCESS_KEY"] = "alsofake"
         enable_flag("TASK_ENABLED_RUN_DATABASE_BACKUP")
-        with self.assertRaises(EnvironmentError):
-            run_database_backup()
+        run_database_backup()
+        mock_call_command_func.assert_has_calls([mock.call("dbbackup")])
 
     @mock.patch("django.core.management.call_command")
     @mock.patch("meshapi.tasks.MESHDB_ENVIRONMENT", "prod")


### PR DESCRIPTION
I discovered that we were not running backups in prod1. It seems to be due to a check on the celery task that does not schedule the backup runs unless we are in prod2, which we no longer are.

This will be a noop in not-prod1 because the task won't run due to the decorator on the task itself.

With this change, we must be careful not to enable backups on dev, because now they will actually run.