### PR TITLE
Replace py3-validate-email with email-validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "python-dotenv==1.0.*",
     "stringcase==1.2.*",
     "python-dotenv==1.0.*",
-    "py3-validate-email @ git+https://git.ksol.io/karolyi/py3-validate-email@v1.0.12",
+    "email-validator==2.*",
     "phonenumbers==8.13.*",
     "requests==2.32.*",
     "requests-mock==1.12.*",

--- a/src/meshapi/tests/test_join_form.py
+++ b/src/meshapi/tests/test_join_form.py
@@ -11,7 +11,6 @@ from django.db.models import Q
 from django.test import Client, TestCase, TransactionTestCase
 from flags.state import enable_flag
 from parameterized import parameterized
-from validate_email.exceptions import DNSTimeoutError, SMTPTemporaryError
 
 from meshapi.models import Building, Install, Member, Node
 from meshapi.views import JoinFormRequest
@@ -390,47 +389,22 @@ class TestJoinForm(TestCase):
             f"status code incorrect for invalid email valid phone. Should be {code}, but got {response.status_code}.\n Response is: {response.content.decode('utf-8')}",
         )
 
-    @patch("meshapi.validation.validate_email_or_fail")
-    def test_email_parsing_fails(self, mock_validate):
-        mock_validate.side_effect = DNSTimeoutError()
-        request, _ = pull_apart_join_form_submission(valid_join_form_submission)
-
-        response = self.c.post("/api/v1/join/", request, content_type="application/json")
-        code = 500
-        self.assertEqual(
-            code,
-            response.status_code,
-            f"status code incorrect for invalid email valid phone. Should be {code}, but got {response.status_code}.\n Response is: {response.content.decode('utf-8')}",
-        )
-
-    @patch("meshapi.validation.validate_email_or_fail")
-    def test_email_parsing_fails_temporary_issue(self, mock_validate):
-        mock_validate.side_effect = SMTPTemporaryError({"err": "temporary mock issue"})
-        request, _ = pull_apart_join_form_submission(valid_join_form_submission)
-
-        response = self.c.post("/api/v1/join/", request, content_type="application/json")
-        code = 201
-        self.assertEqual(
-            code,
-            response.status_code,
-            f"status code incorrect for invalid email valid phone. Should be {code}, but got {response.status_code}.\n Response is: {response.content.decode('utf-8')}",
-        )
-
-    @patch("meshapi.validation.validate_email_or_fail")
-    def test_email_parsing_fails_temporary_issue_bad_email(self, mock_validate):
-        """Check that an invalid email is given the benefit of the doubt when SMTPTemporaryError is thrown"""
-        mock_validate.side_effect = SMTPTemporaryError({"err": "temporary mock issue"})
+    @patch("meshapi.validation.validate_email_address")
+    def test_invalid_email_returns_400_when_validator_rejects(self, mock_validate):
+        """Verify the view returns 400 when validate_email_address() returns False."""
         submission = valid_join_form_submission.copy()
-
         submission["email_address"] = "aljksdafljkasfjldsaf"
-        request, _ = pull_apart_join_form_submission(valid_join_form_submission)
+        request, _ = pull_apart_join_form_submission(submission)
+
+        mock_validate.return_value = False
 
         response = self.c.post("/api/v1/join/", request, content_type="application/json")
-        code = 201
+        code = 400
         self.assertEqual(
             code,
             response.status_code,
-            f"status code incorrect for invalid email valid phone. Should be {code}, but got {response.status_code}.\n Response is: {response.content.decode('utf-8')}",
+            f"status code incorrect for invalid email. Should be {code}, but got {response.status_code}.\n"
+            f"Response is: {response.content.decode('utf-8')}",
         )
 
     def test_non_nyc_join_form(self):

--- a/src/meshapi/validation.py
+++ b/src/meshapi/validation.py
@@ -7,15 +7,8 @@ from typing import List, Optional
 import phonenumbers
 import requests
 from django.core.exceptions import ValidationError
+from email_validator import EmailNotValidError, validate_email
 from flags.state import flag_state
-from validate_email import validate_email_or_fail
-from validate_email.exceptions import (
-    DNSTimeoutError,
-    EmailValidationError,
-    SMTPCommunicationError,
-    SMTPTemporaryError,
-    TLSNegotiationError,
-)
 
 from meshapi.exceptions import AddressAPIError, InvalidAddressError, UnsupportedAddressError
 from meshapi.util.constants import DEFAULT_EXTERNAL_API_TIMEOUT_SECONDS, INVALID_ALTITUDE
@@ -43,26 +36,15 @@ RECAPTCHA_TOKEN_VALIDATION_URL = "https://www.google.com/recaptcha/api/siteverif
 INVALID_BIN_NUMBERS = [-2, -1, 0, 1000000, 2000000, 3000000, 4000000]
 
 
-def validate_email_address(email_address: str) -> Optional[bool]:
+def validate_email_address(email_address: str) -> bool:
     try:
-        return validate_email_or_fail(
-            email_address=email_address,
-            check_format=True,
-            check_blacklist=True,
-            check_dns=True,
-            dns_timeout=5,
-            check_smtp=False,
-        )
-    except SMTPTemporaryError:
-        # SMTPTemporaryError indicates address validity
-        # is ambiguous. We give the submitter the benefit of the doubt in this case
+        # email_validator checks syntax and (with check_deliverability=True) DNS/MX records.
+        # Transient DNS issues are handled by the library as "unknown deliverability" and do not raise,
+        # so we no longer need separate timeout/SMTP exception handling.
+        validate_email(email_address, check_deliverability=True, timeout=5)
         return True
-    except (DNSTimeoutError, SMTPCommunicationError, TLSNegotiationError) as error:
-        # These errors indicate a transient failure in our ability to validate the requested email,
-        # re-raise the exception to trigger a 500 at the top level handler
-        raise error
-    except EmailValidationError:
-        # Failures for any other reason indicate the email address is invalid, and we should 400 them
+    except EmailNotValidError:
+        # The address is syntactically invalid or its domain is not deliverable.
         return False
 
 

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -17,7 +17,6 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework_dataclasses.serializers import DataclassSerializer
-from validate_email.exceptions import EmailValidationError
 
 from meshapi.exceptions import InvalidAddressError, UnsupportedAddressError
 from meshapi.models import AddressTruthSource, Building, Install, Member, Node
@@ -160,18 +159,8 @@ def process_join_form(r: JoinFormRequest, request: Optional[Request] = None) -> 
     if not r.email_address:
         return Response({"detail": "Must provide an email"}, status=status.HTTP_400_BAD_REQUEST)
 
-    try:
-        if r.email_address and not validate_email_address(r.email_address):
-            return Response({"detail": f"{r.email_address} is not a valid email"}, status=status.HTTP_400_BAD_REQUEST)
-    except EmailValidationError:
-        # DNSTimeoutError, SMTPCommunicationError, and TLSNegotiationError are all subclasses of EmailValidationError.
-        # Any other EmailValidationError will be caught inside validate_email_address() and trigger a return false,
-        # so we know that if validate_email_address() throws, EmailValidationError, it must be one of these
-        # and therefore our fault
-        return Response(
-            {"detail": "Could not validate email address due to an internal error"},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+    if r.email_address and not validate_email_address(r.email_address):
+        return Response({"detail": f"{r.email_address} is not a valid email"}, status=status.HTTP_400_BAD_REQUEST)
 
     # Expects country code!!!!
     if r.phone_number and not validate_phone_number(r.phone_number):


### PR DESCRIPTION
## Why

The [py3-validate-email](https://git.ksol.io/karolyi/py3-validate-email) library has been sabotaged by its author who intentionally inserted a racial slur into it's license. This in turn triggered PyPi, Github, and others, to ban the repo. Needless to say, MeshDB should not continue to use it as a dependency. 

This PR replaces `py3-validate-email` with [`email-validator`](https://github.com/JoshData/python-email-validator) (v2.x), a  library that is used internally by pydantic, fastAPI, and other major Python packages.

## Code Changes

### `pyproject.toml`
- Swap `py3-validate-email @ git+https://git.ksol.io/karolyi/py3-validate-email@v1.0.12` → `email-validator==2.*`.

### `src/meshapi/validation.py`
- Replace `validate_email_or_fail()` with `email_validator.validate_email(check_deliverability=True, timeout=5)`.
- Collapse five exception types (`DNSTimeoutError`, `SMTPCommunicationError`, `TLSNegotiationError`, `SMTPTemporaryError`, `EmailValidationError`) into a single `EmailNotValidError` catch.
- Simplify return type from `Optional[bool]` → `bool`.

### `src/meshapi/views/forms.py`
- Remove `try/except EmailValidationError` wrapper around the validation call — no longer needed since `validate_email_address()` now always returns `True`/`False` without raising.
- Remove `from validate_email.exceptions import EmailValidationError`.

### `src/meshapi/tests/test_join_form.py`
- Remove three tests that exercised old exception paths (`DNSTimeoutError` → 500, `SMTPTemporaryError` → 201, `SMTPTemporaryError` + bad email → 201).
- Add one test verifying the simplified contract: `validate_email_address()` returns `False` → view returns 400.

## Behavior Changes

#### Valid email:
before: 201 
after: 201

#### Invalid syntax / undeliverable domain:
before: 400 
after: 400

#### DNS timeout:
before: 500 (re-raised as internal error) 
after: 201 (allowed through)

#### SMTP temporary error:
before: 201 (benefit of the doubt)
after: N/A — no SMTP check performed


The only user-facing behavior change is **DNS timeouts**: previously these returned a 500 error to the user, blocking potentially legitimate submissions. Now the email-validator library treats DNS timeouts as "unknown deliverability" (returns successfully without raising), so the submission proceeds. I feel like this mostly aligns with the pre-existing "benefit of the doubt" philosophy already applied to SMTP issues.

Note: The new library does **not** perform SMTP checks (connecting to the mail server to verify the recipient). That being said, this actually matches our previous library configuration: `check_smtp=False`