### PR TITLE
scramble script improvements + misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ If you would like to develop in a [Dev Container](https://code.visualstudio.com/
 
 ### with Host
 
+If you are using NixOS, activate the dev environment with `nix-shell`, and then proceed with the below instructions.
+
 If you would like to develop directly on your host machine
 
 Install Python 3.11 and pip.

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,9 @@
 (pkgs.buildFHSEnv {
   name = "pipzone";
   targetPkgs = pkgs: (with pkgs; [
-    python311
-    python311Packages.pip
-    python311Packages.virtualenv
+    python312
+    python312Packages.pip
+    python312Packages.virtualenv
   ]);
   runScript = "zsh";
 }).env

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 (pkgs.buildFHSEnv {
   name = "pipzone";
   targetPkgs = pkgs: (with pkgs; [
-    python312
+    python311
     python312Packages.pip
     python312Packages.virtualenv
   ]);

--- a/src/meshapi/admin/inlines.py
+++ b/src/meshapi/admin/inlines.py
@@ -205,7 +205,6 @@ class AdditionalMembersInline(TabularInline):
     show_change_link = True
 
     def name(self, instance: Any) -> str:
-        print(type(instance))
         return instance.member.name if instance.member else "-"
 
     def primary_email_address(self, instance: Any) -> str:

--- a/src/meshapi/management/commands/scramble_members.py
+++ b/src/meshapi/management/commands/scramble_members.py
@@ -9,7 +9,10 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from faker import Faker
 
+from django.contrib.auth.models import User
+
 from meshapi.models import LOS, Install, Member
+from meshapi.models.billing import InstallFeeBillingDatum
 from meshapi.models.building import Building
 from meshapi.models.devices.device import Device
 from meshapi.models.link import Link
@@ -35,6 +38,66 @@ class Command(BaseCommand):
             "--skip-installs",
             action="store_true",
             help="Skip scrambling installs",
+        )
+        parser.add_argument(
+            "--skip-buildings",
+            action="store_true",
+            help="Skip scrambling buildings",
+        )
+        parser.add_argument(
+            "--skip-devices",
+            action="store_true",
+            help="Skip scrambling devices",
+        )
+        parser.add_argument(
+            "--skip-links",
+            action="store_true",
+            help="Skip scrambling links",
+        )
+        parser.add_argument(
+            "--skip-nodes",
+            action="store_true",
+            help="Skip scrambling nodes",
+        )
+        parser.add_argument(
+            "--skip-loses",
+            action="store_true",
+            help="Skip scrambling LOSes",
+        )
+        parser.add_argument(
+            "--skip-users",
+            action="store_true",
+            help="Skip deleting all users",
+        )
+        parser.add_argument(
+            "--skip-historical",
+            action="store_true",
+            help="Skip deleting all historical records",
+        )
+        parser.add_argument(
+            "--skip-sessions",
+            action="store_true",
+            help="Skip truncating django_session table",
+        )
+        parser.add_argument(
+            "--skip-billing",
+            action="store_true",
+            help="Skip truncating install fee billing data",
+        )
+        parser.add_argument(
+            "--skip-explorer",
+            action="store_true",
+            help="Skip truncating explorer tables",
+        )
+        parser.add_argument(
+            "--skip-silk",
+            action="store_true",
+            help="Skip truncating silk tables",
+        )
+        parser.add_argument(
+            "--skip-admin-log",
+            action="store_true",
+            help="Skip truncating django_admin_log",
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
@@ -73,6 +136,8 @@ class Command(BaseCommand):
                 for install in installs:
                     install.unit = randrange(100)
                     install.notes = fake.text()
+                    install.referral = fake.text()
+                    install.stripe_subscription_id = ""
                     install.request_date, install.install_date, install.abandon_date = self.fuzz_dates(
                         install.request_date, install.install_date, install.abandon_date
                     )
@@ -80,60 +145,131 @@ class Command(BaseCommand):
 
         logging.info("Scrambling all other notes and dates")
 
-        logging.info("Scrambling buildings...")
-        with transaction.atomic():
-            buildings = Building.objects.all()
-            for building in buildings:
-                building.notes = fake.text()
-                # Fuzz the street address, if possible
-                if building.street_address:
-                    address = building.street_address.split(" ")
-                    if len(address) > 0:
-                        try:
-                            fuzzed_street_number = str(int(address[0]) + randint(1, 20))
-                            street_name = " ".join(address[1:])
-                            building.street_address = f"{fuzzed_street_number} {street_name}"
-                        except ValueError:
-                            pass
+        if not options["skip_buildings"]:
+            logging.info("Scrambling buildings...")
+            with transaction.atomic():
+                buildings = Building.objects.all()
+                for building in buildings:
+                    building.notes = fake.text()
+                    # Fuzz the street address, if possible
+                    if building.street_address:
+                        address = building.street_address.split(" ")
+                        if len(address) > 0:
+                            try:
+                                fuzzed_street_number = str(int(address[0]) + randint(1, 20))
+                                street_name = " ".join(address[1:])
+                                building.street_address = f"{fuzzed_street_number} {street_name}"
+                            except ValueError:
+                                pass
 
-                building.save()
+                    building.save()
 
-        logging.info("Scrambling devices...")
-        with transaction.atomic():
-            devices = Device.objects.all()
-            for device in devices:
-                device.notes = fake.text()
-                _, device.install_date, device.abandon_date = self.fuzz_dates(
-                    date.today(), device.install_date, device.abandon_date
-                )
-                device.save()
+        if not options["skip_devices"]:
+            logging.info("Scrambling devices...")
+            with transaction.atomic():
+                devices = Device.objects.all()
+                for device in devices:
+                    device.notes = fake.text()
+                    _, device.install_date, device.abandon_date = self.fuzz_dates(
+                        date.today(), device.install_date, device.abandon_date
+                    )
+                    device.save()
 
-        logging.info("Scrambling links...")
-        with transaction.atomic():
-            links = Link.objects.all()
-            for link in links:
-                link.notes = fake.text()
-                _, link.install_date, link.abandon_date = self.fuzz_dates(
-                    date.today(), link.install_date, link.abandon_date
-                )
-                link.save()
+        if not options["skip_links"]:
+            logging.info("Scrambling links...")
+            with transaction.atomic():
+                links = Link.objects.all()
+                for link in links:
+                    link.notes = fake.text()
+                    _, link.install_date, link.abandon_date = self.fuzz_dates(
+                        date.today(), link.install_date, link.abandon_date
+                    )
+                    link.save()
 
-        logging.info("Scrambling nodes...")
-        with transaction.atomic():
-            nodes = Node.objects.all()
-            for node in nodes:
-                node.notes = fake.text()
-                _, node.install_date, node.abandon_date = self.fuzz_dates(
-                    date.today(), node.install_date, node.abandon_date
-                )
-                node.save()
+        if not options["skip_nodes"]:
+            logging.info("Scrambling nodes...")
+            with transaction.atomic():
+                nodes = Node.objects.all()
+                for node in nodes:
+                    node.notes = fake.text()
+                    _, node.install_date, node.abandon_date = self.fuzz_dates(
+                        date.today(), node.install_date, node.abandon_date
+                    )
+                    node.save()
 
-        logging.info("Scrambling LOSes...")
-        with transaction.atomic():
-            LOSes = LOS.objects.all()
-            for los in LOSes:
-                los.notes = fake.text()
-                los.save()
+        if not options["skip_loses"]:
+            logging.info("Scrambling LOSes...")
+            with transaction.atomic():
+                LOSes = LOS.objects.all()
+                for los in LOSes:
+                    los.notes = fake.text()
+                    los.save()
+
+        if not options["skip_users"]:
+            logging.info("Deleting all users...")
+            with transaction.atomic():
+                User.objects.all().delete()
+                logging.info("All users deleted.")
+
+        if not options["skip_historical"]:
+            logging.info("Deleting all historical records...")
+            with transaction.atomic():
+                apps = __import__("django.apps", fromlist=["apps"])
+                historical_models = [
+                    model for model in apps.apps.get_models() if model.__name__.startswith("Historical")
+                ]
+                for model in historical_models:
+                    count = model.objects.all().count()
+                    model.objects.all().delete()
+                    logging.info(f"Deleted {count} historical records from {model.__name__}")
+                logging.info("All historical records deleted.")
+
+        if not options["skip_sessions"]:
+            logging.info("Truncating django_session table...")
+            with transaction.atomic():
+                from django.contrib.sessions.models import Session
+
+                count = Session.objects.all().count()
+                Session.objects.all().delete()
+                logging.info(f"Deleted {count} session records.")
+
+        if not options["skip_billing"]:
+            logging.info("Truncating install fee billing data...")
+            with transaction.atomic():
+                count = InstallFeeBillingDatum.objects.all().count()
+                InstallFeeBillingDatum.objects.all().delete()
+                logging.info(f"Deleted {count} billing records.")
+
+        if not options["skip_explorer"]:
+            logging.info("Truncating explorer tables...")
+            with transaction.atomic():
+                apps = __import__("django.apps", fromlist=["apps"])
+                explorer_models = [model for model in apps.apps.get_models() if model.__module__.startswith("explorer")]
+                for model in explorer_models:
+                    count = model.objects.all().count()
+                    model.objects.all().delete()
+                    logging.info(f"Deleted {count} records from {model.__name__}")
+                logging.info("All explorer tables truncated.")
+
+        if not options["skip_silk"]:
+            logging.info("Truncating silk tables...")
+            with transaction.atomic():
+                apps = __import__("django.apps", fromlist=["apps"])
+                silk_models = [model for model in apps.apps.get_models() if model.__module__.startswith("silk")]
+                for model in silk_models:
+                    count = model.objects.all().count()
+                    model.objects.all().delete()
+                    logging.info(f"Deleted {count} records from {model.__name__}")
+                logging.info("All silk tables truncated.")
+
+        if not options["skip_admin_log"]:
+            logging.info("Truncating django_admin_log...")
+            with transaction.atomic():
+                from django.contrib.admin.models import LogEntry
+
+                count = LogEntry.objects.all().count()
+                LogEntry.objects.all().delete()
+                logging.info(f"Deleted {count} admin log entries.")
 
         logging.info("Done")
 

--- a/src/meshapi/management/commands/scramble_members.py
+++ b/src/meshapi/management/commands/scramble_members.py
@@ -5,11 +5,10 @@ from datetime import date, timedelta
 from random import randint, randrange
 from typing import Any, Optional, Tuple
 
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from faker import Faker
-
-from django.contrib.auth.models import User
 
 from meshapi.models import LOS, Install, Member
 from meshapi.models.billing import InstallFeeBillingDatum

--- a/src/meshapi/tests/test_nn.py
+++ b/src/meshapi/tests/test_nn.py
@@ -957,3 +957,93 @@ class TestNNRaceCondition(TransactionTestCase):
             resp_nn,
             f"nn incorrect for test_nn_valid_install_number. Should be {expected_nn}, but got {resp_nn}",
         )
+
+
+class TestSavingNodesWhenInstallWithNNIsActiveAndOnAnotherNode(TransactionTestCase):
+    admin_c = Client()
+
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+        self.admin_c.login(username="admin", password="admin_password")
+
+        member_obj = Member(**sample_member)
+        member_obj.save()
+
+        # Building A — the shared building between node_a and node_b
+        self.building_a = Building(**sample_building)
+        self.building_a.save()
+
+        # Building B — only on node_b, so the building sets are NOT equal
+        self.building_b = Building(**sample_building)
+        self.building_b.save()
+
+        # Node A holds NN 1001 — this is the pre-existing NN holder
+        # Has Building A only
+        self.node_a = Node(
+            network_number=1001,
+            status=Node.NodeStatus.PLANNED,
+            type=Node.NodeType.STANDARD,
+            latitude=0,
+            longitude=0,
+        )
+        self.node_a.save()
+        self.node_a.buildings.add(self.building_a)
+
+        # Node B holds the active install — has Building A only (same set as node_a)
+        self.node_b = Node(
+            network_number=1002,
+            status=Node.NodeStatus.ACTIVE,
+            type=Node.NodeType.STANDARD,
+            latitude=1,
+            longitude=1,
+        )
+        self.node_b.save()
+        self.node_b.buildings.add(self.building_a)
+
+        # Create an active install with install_number=1001, attached to node_b
+        inst = sample_install.copy()
+        if inst["abandon_date"] == "":
+            inst["abandon_date"] = None
+        inst["status"] = Install.InstallStatus.ACTIVE
+        inst["building"] = self.building_a
+        inst["member"] = member_obj
+
+        self.active_install = Install(**inst)
+        self.active_install.install_number = 1001
+        self.active_install.node = self.node_b
+        self.active_install.save()
+
+        # This node will be modified to have NN=1001
+        self.other_node = Node(
+            status=Node.NodeStatus.PLANNED,
+            type=Node.NodeType.STANDARD,
+            latitude=2,
+            longitude=2,
+        )
+        self.other_node.save()
+        self.other_node.buildings.add(self.building_a)
+
+    def test_node_with_nn_matching_active_install_can_be_saved_when_sharing_buildings(self):
+        # The Jefferson situation: a node whose network_number matches an active
+        # install's install number, where that install is attached to a different node,
+        # but the pre-existing NN holder (node_a) and the install's node (node_b)
+        # share the exact same set of buildings. This should succeed with a warning.
+        self.node_a.notes = "Chom"
+        self.node_a.save()
+        self.node_a.refresh_from_db()
+        self.assertEqual(self.node_a.network_number, 1001)
+
+    def test_node_with_nn_matching_active_install_fails_when_no_identical_building_sets(self):
+        # If the pre-existing NN holder and the install's node do NOT share the
+        # exact same set of buildings, it should fail with ValueError
+        # Add building_b to node_b so the building sets differ
+        self.node_b.buildings.add(self.building_b)
+
+        self.node_a.notes = "Chom"
+
+        with self.assertRaises(ValueError) as context:
+            self.node_a.save()
+
+        self.assertIn("has an install associated", str(context.exception))

--- a/src/meshapi/tests/test_nn.py
+++ b/src/meshapi/tests/test_nn.py
@@ -959,7 +959,7 @@ class TestNNRaceCondition(TransactionTestCase):
         )
 
 
-class TestSavingNodesWhenInstallWithNNIsActiveAndOnAnotherNode(TransactionTestCase):
+class TestSavingExistingNodeWhenNNMatchesInstallNumberOfActiveNode(TransactionTestCase):
     admin_c = Client()
 
     def setUp(self):
@@ -1002,6 +1002,16 @@ class TestSavingNodesWhenInstallWithNNIsActiveAndOnAnotherNode(TransactionTestCa
         self.node_b.save()
         self.node_b.buildings.add(self.building_a)
 
+        self.node_c = Node(
+            network_number=1003,
+            status=Node.NodeStatus.PLANNED,
+            type=Node.NodeType.STANDARD,
+            latitude=0,
+            longitude=0,
+        )
+        self.node_c.save()
+        self.node_c.buildings.add(self.building_a)
+
         # Create an active install with install_number=1001, attached to node_b
         inst = sample_install.copy()
         if inst["abandon_date"] == "":
@@ -1015,6 +1025,11 @@ class TestSavingNodesWhenInstallWithNNIsActiveAndOnAnotherNode(TransactionTestCa
         self.active_install.node = self.node_b
         self.active_install.save()
 
+        self.active_install = Install(**inst)
+        self.active_install.install_number = 1004
+        self.active_install.node = self.node_b
+        self.active_install.save()
+
         # This node will be modified to have NN=1001
         self.other_node = Node(
             status=Node.NodeStatus.PLANNED,
@@ -1025,25 +1040,18 @@ class TestSavingNodesWhenInstallWithNNIsActiveAndOnAnotherNode(TransactionTestCa
         self.other_node.save()
         self.other_node.buildings.add(self.building_a)
 
-    def test_node_with_nn_matching_active_install_can_be_saved_when_sharing_buildings(self):
-        # The Jefferson situation: a node whose network_number matches an active
-        # install's install number, where that install is attached to a different node,
-        # but the pre-existing NN holder (node_a) and the install's node (node_b)
-        # share the exact same set of buildings. This should succeed with a warning.
+    def test_node_with_nn_matching_active_install_can_be_saved(self):
         self.node_a.notes = "Chom"
         self.node_a.save()
         self.node_a.refresh_from_db()
         self.assertEqual(self.node_a.network_number, 1001)
 
-    def test_node_with_nn_matching_active_install_fails_when_no_identical_building_sets(self):
-        # If the pre-existing NN holder and the install's node do NOT share the
-        # exact same set of buildings, it should fail with ValueError
-        # Add building_b to node_b so the building sets differ
-        self.node_b.buildings.add(self.building_b)
+    def test_changing_node_nn_to_number_of_active_install_fails_because_nn_immutable(self):
+        from django.core.exceptions import ValidationError
 
-        self.node_a.notes = "Chom"
+        self.node_c.network_number = 1004
 
-        with self.assertRaises(ValueError) as context:
-            self.node_a.save()
+        with self.assertRaises(ValidationError) as context:
+            self.node_c.save()
 
-        self.assertIn("has an install associated", str(context.exception))
+        self.assertIn("Network number is immutable once set", str(context.exception))

--- a/src/meshapi/util/network_number.py
+++ b/src/meshapi/util/network_number.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from typing import Optional
 
@@ -59,6 +60,23 @@ def validate_network_number_unused_and_claim_install_if_needed(
             return
 
         if nn_donor_install.status == Install.InstallStatus.ACTIVE:
+            if (
+                pre_existing_node_with_nn
+                and nn_donor_install.node
+                and (set(pre_existing_node_with_nn.buildings.all()) == set(nn_donor_install.node.buildings.all()))
+            ):
+                # This usually we means we can't use this install's number, because the install is active.
+                # However, there are edge cases where saving a node with the same NN as an install's number is valid, such as at, *sigh*... Jefferson. So, we need
+                # to check if this Install's Node and the network_number_candidate share buildings, like at Jefferson. If they do, we
+                # shouldn't raise an error and instead just log a warning and return.
+                # XXX (wdn): Perhaps this check ought to be for new nodes being saved for the first time.
+                logging.warning(
+                    f"NN{network_number_candidate} has a Jefferson situation. This pre-existing Node's NN matches an install's "
+                    f"install number, and that install is active and connected to another Node. However, that "
+                    "install shares a building with that pre-existing Node. Therefore, we won't touch the install."
+                )
+                return
+
             raise ValueError(
                 f"Invalid NN: {network_number_candidate} has an install associated that "
                 f"looks active (#{nn_donor_install.install_number})"

--- a/src/meshapi/util/network_number.py
+++ b/src/meshapi/util/network_number.py
@@ -66,14 +66,16 @@ def validate_network_number_unused_and_claim_install_if_needed(
                 and (set(pre_existing_node_with_nn.buildings.all()) == set(nn_donor_install.node.buildings.all()))
             ):
                 # This usually we means we can't use this install's number, because the install is active.
-                # However, there are edge cases where saving a node with the same NN as an install's number is valid, such as at, *sigh*... Jefferson. So, we need
-                # to check if this Install's Node and the network_number_candidate share buildings, like at Jefferson. If they do, we
-                # shouldn't raise an error and instead just log a warning and return.
+                # However, there are edge cases where saving a node with the same NN as an install's number is
+                # valid, such as at, *sigh*... Jefferson. So, we need to check if this Install's Node and the
+                # network_number_candidate share buildings, like at Jefferson. If they do, we shouldn't raise an
+                # error and instead just log a warning and return.
                 # XXX (wdn): Perhaps this check ought to be for new nodes being saved for the first time.
                 logging.warning(
-                    f"NN{network_number_candidate} has a Jefferson situation. This pre-existing Node's NN matches an install's "
-                    f"install number, and that install is active and connected to another Node. However, that "
-                    "install shares a building with that pre-existing Node. Therefore, we won't touch the install."
+                    f"NN{network_number_candidate} has a Jefferson situation. This pre-existing Node's NN matches"
+                    f"an install's install number, and that install is active and connected to another Node."
+                    f"However, that install shares a building with that pre-existing Node. Therefore, we won't"
+                    f"touch the install."
                 )
                 return
 

--- a/src/meshapi/util/network_number.py
+++ b/src/meshapi/util/network_number.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 from typing import Optional
 
@@ -52,6 +51,9 @@ def validate_network_number_unused_and_claim_install_if_needed(
     if pre_existing_node_with_nn is not None and pre_existing_node_with_nn.id != pre_existing_node_id:
         raise ValueError("Network number already in use by another node")
 
+    if pre_existing_node_with_nn is not None and pre_existing_node_with_nn.id == pre_existing_node_id:
+        return
+
     nn_donor_install = Install.objects.select_for_update().filter(install_number=network_number_candidate).first()
     if nn_donor_install:
         if pre_existing_node_id and nn_donor_install.node_id == pre_existing_node_id:
@@ -60,25 +62,6 @@ def validate_network_number_unused_and_claim_install_if_needed(
             return
 
         if nn_donor_install.status == Install.InstallStatus.ACTIVE:
-            if (
-                pre_existing_node_with_nn
-                and nn_donor_install.node
-                and (set(pre_existing_node_with_nn.buildings.all()) == set(nn_donor_install.node.buildings.all()))
-            ):
-                # This usually we means we can't use this install's number, because the install is active.
-                # However, there are edge cases where saving a node with the same NN as an install's number is
-                # valid, such as at, *sigh*... Jefferson. So, we need to check if this Install's Node and the
-                # network_number_candidate share buildings, like at Jefferson. If they do, we shouldn't raise an
-                # error and instead just log a warning and return.
-                # XXX (wdn): Perhaps this check ought to be for new nodes being saved for the first time.
-                logging.warning(
-                    f"NN{network_number_candidate} has a Jefferson situation. This pre-existing Node's NN matches"
-                    f"an install's install number, and that install is active and connected to another Node."
-                    f"However, that install shares a building with that pre-existing Node. Therefore, we won't"
-                    f"touch the install."
-                )
-                return
-
             raise ValueError(
                 f"Invalid NN: {network_number_candidate} has an install associated that "
                 f"looks active (#{nn_donor_install.install_number})"

--- a/src/meshapi/util/network_number.py
+++ b/src/meshapi/util/network_number.py
@@ -52,6 +52,9 @@ def validate_network_number_unused_and_claim_install_if_needed(
         raise ValueError("Network number already in use by another node")
 
     if pre_existing_node_with_nn is not None and pre_existing_node_with_nn.id == pre_existing_node_id:
+        # This ensures that existing nodes that have an NN that matches the install # of an active
+        # install can be saved. In this case, we don't want to touch that install. We don't need to,
+        # because the node already exists.
         return
 
     nn_donor_install = Install.objects.select_for_update().filter(install_number=network_number_candidate).first()


### PR DESCRIPTION
- Added `--skip-*` flags to selectively skip scrambling individual entity types. In a follow up PR I may change the interface for this because these flags are cumbersome.
- Added more stuff to delete in the scramble script. This will let us use the newer pgdump method of exporting the database.
- Added a fix for the Jefferson Situation, where a node can exist when an install is using its NN as an install #
- Removed debug `print` statement from `src/meshapi/admin/inlines.py:208` that was leaking type info to the console during admin operations
- Added NixOS dev setup instructions to `README.md`, directing NixOS users to activate the environment via `nix-shell`
- Updated `shell.nix` to use Python 3.12 packages instead of Python 3.11 so it actually works. We're still on Python 3.11. need to fix that someday.